### PR TITLE
Change pickle message length to uint32

### DIFF
--- a/pickle.go
+++ b/pickle.go
@@ -15,7 +15,7 @@ func pickle(dp *Datapoint) []byte {
 	list := []interface{}{point}
 	pickler.Encode(list)
 	messageBuf := &bytes.Buffer{}
-	err := binary.Write(messageBuf, binary.BigEndian, uint64(dataBuf.Len()))
+	err := binary.Write(messageBuf, binary.BigEndian, uint32(dataBuf.Len()))
 	if err != nil {
 		log.Fatal(err.Error())
 	}


### PR DESCRIPTION
Receiver Python code uses struct format '!I', a 4-byte quantity, to decode
the length.
