### PR TITLE
[WIP] Use buffer for table dispatch, avoid re-parsing metrics

### DIFF
--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -35,8 +35,8 @@ type Aggregation struct {
 	Substr   string
 	Format   string
 	Cache    bool
-	Interval int
-	Wait     int
+	Interval uint32
+	Wait     uint32
 	DropRaw  bool
 }
 

--- a/cmd/carbon-relay-ng/carbon-relay-ng_test.go
+++ b/cmd/carbon-relay-ng/carbon-relay-ng_test.go
@@ -54,7 +54,7 @@ func init() {
 }
 
 func NewTableOrFatal(tb testing.TB, spool_dir, cmd string) *tbl.Table {
-	table := tbl.New(spool_dir)
+	table := tbl.New(spool_dir, 100)
 	fatal := func(err error) {
 		tb.Fatal(err)
 	}
@@ -299,8 +299,8 @@ func TestAddRewrite(t *testing.T) {
 
 // just dispatch (coming into table), no matching or sending to route
 func BenchmarkTableDispatch(b *testing.B) {
-	logging.SetLevel(logging.WARNING, "carbon-relay-ng")                                         // don't care about unroutable notices
-	metric70 := []byte("abcde_fghij.klmnopqrst.uv_wxyz.1234567890abcdefg 12345.6789 1234567890") // size: key = 48, val = 10, ts = 10 -> 70
+	logging.SetLevel(logging.WARNING, "carbon-relay-ng")                   // don't care about unroutable notices
+	metric70 := []byte("abcde_fghij.klmnopqrst.uv_wxyz.1234567890abcdefg") // size: key = 48, val = 10, ts = 10 -> 70
 	table := NewTableOrFatal(b, "", "")
 	for i := 0; i < b.N; i++ {
 		table.Dispatch(metric70, 12345.6789, 1234567890)
@@ -310,7 +310,7 @@ func BenchmarkTableDispatch(b *testing.B) {
 // i thought conn will drop messages because the tE tcp handler can't keep up.
 // but looks like that's not true (anymore?), it just works without having to sleep after dispatch
 // also note the dummyPackets uses a channel api which probably causes most of the slowdown
-func BenchmarkTableDisPatchAndEndpointReceive(b *testing.B) {
+func BenchmarkTableDispatchAndEndpointReceive(b *testing.B) {
 	logging.SetLevel(logging.WARNING, "carbon-relay-ng") // testendpoint sends a warning because it does something bad with conn at end but it's harmless
 	tE := NewTestEndpointCounter(b, ":2005")
 	tE.Start()
@@ -319,7 +319,7 @@ func BenchmarkTableDisPatchAndEndpointReceive(b *testing.B) {
 	// reminder: go benchmark will invoke this with N = 0, then maybe N = 20, then maybe more
 	// and the time it prints is function run divided by N, which
 	// should be of a more or less stable time, which gets printed
-	metric70 := []byte("abcde_fghij.klmnopqrst.uv_wxyz.1234567890abcdefg 12345.6789 1234567890") // size: key = 48, val = 10, ts = 10 -> 70
+	metric70 := []byte("abcde_fghij.klmnopqrst.uv_wxyz.1234567890abcdefg") // size: key = 48, val = 10, ts = 10 -> 70
 	dest, err := table.GetRoute("test1").GetDestination(0)
 	if err != nil {
 		panic(err)

--- a/destination/bufwriter.go
+++ b/destination/bufwriter.go
@@ -60,7 +60,7 @@ func (b *Writer) flush() error {
 	if log.IsEnabledFor(logging.INFO) {
 		bufs := bytes.Split(b.buf[0:b.n], []byte{'\n'})
 		for _, buf := range bufs {
-			log.Info("bufWriter %s flush-writing to tcp %s\n", b.key, buf)
+			log.Debug("bufWriter %s flush-writing to tcp %s\n", b.key, buf)
 		}
 	}
 	n, err := b.wr.Write(b.buf[0:b.n])
@@ -97,7 +97,7 @@ func (b *Writer) Write(p []byte) (nn int, err error) {
 			// Write directly from p to avoid copy.
 			// we should measure this duration because it's equivalent to a flush
 			start := time.Now()
-			log.Info("bufWriter %s writing to tcp %s\n", b.key, p)
+			log.Debug("bufWriter %s writing to tcp %s\n", b.key, p)
 			n, b.err = b.wr.Write(p)
 			b.durationOverflowFlush.UpdateSince(start)
 		} else {

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -267,7 +267,7 @@ func (dest *Destination) relay() {
 		case conn.In <- point:
 			conn.numBuffered.Inc(1)
 		default:
-			log.Info("dest %s %s nonBlockingSend -> dropping due to slow conn\n", dest.Key, point)
+			log.Debug("dest %s %s nonBlockingSend -> dropping due to slow conn\n", dest.Key, point)
 			// TODO check if it was because conn closed
 			// we don't want to just buffer everything in memory,
 			// it would probably keep piling up until OOM.  let's just drop the traffic.
@@ -281,9 +281,9 @@ func (dest *Destination) relay() {
 	nonBlockingSpool := func(point *util.Point) {
 		select {
 		case dest.spool.InRT <- []byte(point.String()):
-			log.Info("dest %s %s nonBlockingSpool -> added to spool\n", dest.Key, point)
+			log.Debug("dest %s %s nonBlockingSpool -> added to spool\n", dest.Key, point)
 		default:
-			log.Info("dest %s %s nonBlockingSpool -> dropping due to slow spool\n", dest.Key, point)
+			log.Debug("dest %s %s nonBlockingSpool -> dropping due to slow spool\n", dest.Key, point)
 			dest.numDropSlowSpool.Inc(1)
 		}
 	}
@@ -354,7 +354,7 @@ func (dest *Destination) relay() {
 			return
 		case buf := <-toUnspool:
 			// we know that conn != nil here because toUnspool is set above
-			log.Info("dest %v %s received from spool -> nonBlockingSend\n", dest.Key, buf)
+			log.Debug("dest %v %s received from spool -> nonBlockingSend\n", dest.Key, buf)
 			point, err := ParseDataPoint(buf)
 			if err != nil {
 				log.Error("error parsing %s received from spool: %s", buf, err)
@@ -363,13 +363,13 @@ func (dest *Destination) relay() {
 			}
 		case point := <-dest.In:
 			if conn != nil {
-				log.Info("dest %v %s received from In -> nonBlockingSend\n", dest.Key, point)
+				log.Debug("dest %v %s received from In -> nonBlockingSend\n", dest.Key, point)
 				nonBlockingSend(point)
 			} else if dest.Spool {
-				log.Info("dest %v %s received from In -> nonBlockingSpool\n", dest.Key, point)
+				log.Debug("dest %v %s received from In -> nonBlockingSpool\n", dest.Key, point)
 				nonBlockingSpool(point)
 			} else {
-				log.Info("dest %v %s received from In -> no conn no spool -> drop\n", dest.Key, point)
+				log.Debug("dest %v %s received from In -> no conn no spool -> drop\n", dest.Key, point)
 				dest.numDropNoConnNoSpool.Inc(1)
 			}
 		}

--- a/destination/metric.go
+++ b/destination/metric.go
@@ -4,15 +4,11 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/graphite-ng/carbon-relay-ng/util"
 )
 
-type Datapoint struct {
-	Name string
-	Val  float64
-	Time uint32
-}
-
-func ParseDataPoint(buf []byte) (*Datapoint, error) {
+func ParseDataPoint(buf []byte) (*util.Point, error) {
 	str := strings.TrimSpace(string(buf))
 	elements := strings.Fields(str)
 	if len(elements) != 3 {
@@ -27,5 +23,5 @@ func ParseDataPoint(buf []byte) (*Datapoint, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Datapoint{name, val, uint32(timestamp)}, nil
+	return &util.Point{[]byte(name), val, uint32(timestamp)}, nil
 }

--- a/destination/pickle.go
+++ b/destination/pickle.go
@@ -4,15 +4,16 @@ import (
 	"bytes"
 	"encoding/binary"
 
+	"github.com/graphite-ng/carbon-relay-ng/util"
 	"github.com/kisielk/og-rek"
 )
 
-func Pickle(dp *Datapoint) []byte {
+func Pickle(dp *util.Point) []byte {
 	dataBuf := &bytes.Buffer{}
 	pickler := ogórek.NewEncoder(dataBuf)
 
 	// pickle format (in python talk): [(path, (timestamp, value)), ...]
-	point := []interface{}{string(dp.Name), []interface{}{dp.Time, dp.Val}}
+	point := []interface{}{string(dp.Key), []interface{}{dp.TS, dp.Val}}
 	list := []interface{}{point}
 	pickler.Encode(list)
 	messageBuf := &bytes.Buffer{}

--- a/destination/spool.go
+++ b/destination/spool.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Dieterbe/go-metrics"
 	"github.com/graphite-ng/carbon-relay-ng/nsqd"
 	"github.com/graphite-ng/carbon-relay-ng/stats"
+	"github.com/graphite-ng/carbon-relay-ng/util"
 )
 
 // sits in front of nsqd diskqueue.
@@ -100,9 +101,9 @@ func (s *Spool) Writer() {
 	}
 }
 
-func (s *Spool) Ingest(bulkData [][]byte) {
+func (s *Spool) Ingest(bulkData []*util.Point) {
 	for _, buf := range bulkData {
-		s.InBulk <- buf
+		s.InBulk <- []byte(buf.String())
 		time.Sleep(s.spoolSleep)
 	}
 }

--- a/imperatives/imperatives.go
+++ b/imperatives/imperatives.go
@@ -12,6 +12,7 @@ import (
 	"github.com/graphite-ng/carbon-relay-ng/matcher"
 	"github.com/graphite-ng/carbon-relay-ng/rewriter"
 	"github.com/graphite-ng/carbon-relay-ng/route"
+	"github.com/graphite-ng/carbon-relay-ng/util"
 	"github.com/taylorchu/toki"
 )
 
@@ -161,7 +162,7 @@ type Table interface {
 	DelRoute(key string) error
 	UpdateDestination(key string, index int, opts map[string]string) error
 	UpdateRoute(key string, opts map[string]string) error
-	GetIn() chan []byte
+	GetAggIn() chan *util.Point
 	GetSpoolDir() string
 }
 
@@ -297,7 +298,7 @@ func readAddAgg(s *toki.Scanner, table Table) error {
 		}
 	}
 
-	agg, err := aggregator.New(fun, regex, prefix, sub, outFmt, cache, uint(interval), uint(wait), dropRaw, table.GetIn())
+	agg, err := aggregator.New(fun, regex, prefix, sub, outFmt, cache, uint32(interval), uint32(wait), dropRaw, table.GetAggIn())
 	if err != nil {
 		return err
 	}

--- a/imperatives/mocktable_test.go
+++ b/imperatives/mocktable_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/graphite-ng/carbon-relay-ng/matcher"
 	"github.com/graphite-ng/carbon-relay-ng/rewriter"
 	"github.com/graphite-ng/carbon-relay-ng/route"
+	"github.com/graphite-ng/carbon-relay-ng/util"
 )
 
 type mockTable struct {
@@ -17,5 +18,5 @@ func (m *mockTable) AddRoute(route route.Route)                                 
 func (m *mockTable) DelRoute(key string) error                                             { return nil }
 func (m *mockTable) UpdateDestination(key string, index int, opts map[string]string) error { return nil }
 func (m *mockTable) UpdateRoute(key string, opts map[string]string) error                  { return nil }
-func (m *mockTable) GetIn() chan []byte                                                    { return nil }
+func (m *mockTable) GetAggIn() chan *util.Point                                            { return nil }
 func (m *mockTable) GetSpoolDir() string                                                   { return "fake-spool-dir" }

--- a/input/amqp.go
+++ b/input/amqp.go
@@ -150,5 +150,5 @@ func (a *Amqp) dispatch(buf []byte) {
 		}
 	}
 
-	a.table.Dispatch(buf, val, ts)
+	a.table.Dispatch(key, val, ts)
 }

--- a/input/pickle.go
+++ b/input/pickle.go
@@ -188,7 +188,7 @@ ReadLoop:
 			}
 
 			log.Debug("pickle.go: all good, dispatching metrics buffer")
-			p.table.Dispatch(buf, val, ts)
+			p.table.Dispatch(key, val, ts)
 
 			log.Debug("pickle.go: exiting ItemLoop")
 		}

--- a/input/plain.go
+++ b/input/plain.go
@@ -67,6 +67,6 @@ func (p *Plain) Handle(c net.Conn) {
 			}
 		}
 
-		p.table.Dispatch(buf, val, ts)
+		p.table.Dispatch(key, val, ts)
 	}
 }

--- a/route/dispatch.go
+++ b/route/dispatch.go
@@ -1,10 +1,13 @@
 package route
 
-import "github.com/Dieterbe/go-metrics"
+import (
+	"github.com/Dieterbe/go-metrics"
+	"github.com/graphite-ng/carbon-relay-ng/util"
+)
 
 // DispatchNonBlocking will dispatch in to buf.
 // if buf is full, will discard the data
-func dispatchNonBlocking(buf chan []byte, in []byte, gauge metrics.Gauge, drops metrics.Counter) {
+func dispatchNonBlocking(buf chan *util.Point, in *util.Point, gauge metrics.Gauge, drops metrics.Counter) {
 	select {
 	case buf <- in:
 		gauge.Inc(1)
@@ -17,7 +20,7 @@ func dispatchNonBlocking(buf chan []byte, in []byte, gauge metrics.Gauge, drops 
 // If buf is full, the call will block
 // note that in this case, numBuffered will contain size of buffer + number of waiting entries,
 // and hence could be > bufSize
-func dispatchBlocking(buf chan []byte, in []byte, gauge metrics.Gauge, drops metrics.Counter) {
+func dispatchBlocking(buf chan *util.Point, in *util.Point, gauge metrics.Gauge, drops metrics.Counter) {
 	gauge.Inc(1)
 	buf <- in
 }

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/graphite-ng/carbon-relay-ng/destination"
+	"github.com/graphite-ng/carbon-relay-ng/util"
 )
 
 // just sending into route, no matching or sending to dest
@@ -12,7 +13,11 @@ func BenchmarkRouteDispatchMetric(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	metric70 := []byte("abcde_fghij.klmnopqrst.uv_wxyz.1234567890abcdefg 12345.6789 1234567890") // key = 48, val = 10, ts = 10 -> 70
+	metric70 := &util.Point{
+		[]byte("abcde_fghij.klmnopqrst.uv_wxyz.1234567890abcdefg"),
+		float64(12345.6789),
+		uint32(1234567890),
+	}
 	for i := 0; i < b.N; i++ {
 		route.Dispatch(metric70)
 	}

--- a/route/schemas_test.go
+++ b/route/schemas_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/lomik/go-carbon/persister"
 	"gopkg.in/raintank/schema.v1"
+
+	"github.com/graphite-ng/carbon-relay-ng/util"
 )
 
 func getMatchEverythingSchemas() persister.WhisperSchemas {
@@ -32,7 +34,11 @@ func TestParseMetricWithTags(t *testing.T) {
 	value := float64(100)
 	name := "a.b.c"
 	nameWithTags := fmt.Sprintf("%s;%s", name, strings.Join(tags, ";"))
-	line := []byte(fmt.Sprintf("%s %f %d", nameWithTags, value, time))
+	line := &util.Point{
+		[]byte(nameWithTags),
+		float64(value),
+		uint32(time),
+	}
 	md, _ := parseMetric(line, schemas, 1)
 	sort.Strings(tags)
 	expectedMd := &schema.MetricData{
@@ -56,7 +62,11 @@ func TestParseMetricWithoutTags(t *testing.T) {
 	time := int64(200)
 	value := float64(100)
 	name := "a.b.c"
-	line := []byte(fmt.Sprintf("%s %f %d", name, value, time))
+	line := &util.Point{
+		[]byte(name),
+		float64(value),
+		uint32(time),
+	}
 	md, _ := parseMetric(line, schemas, 1)
 	expectedMd := &schema.MetricData{
 		Name:     name,

--- a/table/table.go
+++ b/table/table.go
@@ -91,12 +91,14 @@ func (table *Table) GetSpoolDir() string {
 // it dispatches incoming metrics into matching aggregators and routes,
 // after checking against the blacklist
 // key is assumed to have no whitespace at the end
-func (table *Table) Dispatch(key []byte, val float64, ts uint32) {
+func (table *Table) Dispatch(buf []byte, val float64, ts uint32) {
+	key := make([]byte, len(buf))
+	copy(key, buf)
 	table.In <- &util.Point{key, val, ts}
 }
 
 func (table *Table) DispatchIn(point *util.Point) {
-	log.Debug("table received point %s", point)
+	log.Debug("table received point '%s'", point)
 
 	conf := table.config.Load().(TableConfig)
 

--- a/ui/web/bindata.go
+++ b/ui/web/bindata.go
@@ -105,7 +105,7 @@ func admin_http_assetsAppJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "admin_http_assets/app.js", size: 4809, mode: os.FileMode(436), modTime: time.Unix(1524523343, 0)}
+	info := bindataFileInfo{name: "admin_http_assets/app.js", size: 4809, mode: os.FileMode(436), modTime: time.Unix(1524691891, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -125,7 +125,7 @@ func admin_http_assetsIndexHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "admin_http_assets/index.html", size: 15961, mode: os.FileMode(500), modTime: time.Unix(1524523432, 0)}
+	info := bindataFileInfo{name: "admin_http_assets/index.html", size: 15961, mode: os.FileMode(436), modTime: time.Unix(1524691891, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/ui/web/web.go
+++ b/ui/web/web.go
@@ -222,8 +222,8 @@ func parseAggregateRequest(r *http.Request) (*aggregator.Aggregator, *handlerErr
 		Fun       string
 		OutFmt    string
 		Cache     bool
-		Interval  uint
-		Wait      uint
+		Interval  uint32
+		Wait      uint32
 		DropRaw   bool
 		Regex     string
 		Prefix    string `json:"omitempty"`

--- a/util/util.go
+++ b/util/util.go
@@ -1,6 +1,9 @@
 package util
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // some.host:2003 -> some_host_2003
 // http://some.host:8080 -> http_some_host_8080
@@ -14,4 +17,14 @@ func AddrToPath(s string) string {
 // http://some.host:8080, kafkaRoute -> kafkaRoute_http_some_host_8080
 func Key(routeName, addr string) string {
 	return routeName + "_" + AddrToPath(addr)
+}
+
+type Point struct {
+	Key []byte
+	Val float64
+	TS  uint32
+}
+
+func (point *Point) String() string {
+	return fmt.Sprintf("%s %f %d", point.Key, point.Val, point.TS)
 }

--- a/util/util.go
+++ b/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -26,5 +27,5 @@ type Point struct {
 }
 
 func (point *Point) String() string {
-	return fmt.Sprintf("%s %f %d", point.Key, point.Val, point.TS)
+	return fmt.Sprintf("%s %s %d", point.Key, strconv.FormatFloat(point.Val, 'f', -1, 64), point.TS)
 }


### PR DESCRIPTION
This PR is a work in progress, it attempts to refactor the table dispatch mechanism to use a buffer for metrics coming from the input plugins, and removes the buffer used for aggregations (though I'm not sure whether there's still utility in keeping that).  It also attempts to switch from passing raw byte-arrays around and re-parsing them at various stages to having the inputs parse into a standard internal format that can be passed around safely without needing to be re-parsed.  I also tweaked a few types to avoid unnecessary type-juggling where possible, mostly for the timestamps.

This is still very rough, and I haven't yet added a config parameter for the size of the table input buffer.