### PR TITLE
response body must be read

### DIFF
--- a/route/grafananet.go
+++ b/route/grafananet.go
@@ -238,6 +238,7 @@ func (route *GrafanaNet) flush(shard int) {
 				route.tickFlushSize.Update(int64(len(data)))
 				route.durationTickFlush.Update(diff)
 
+				ioutil.ReadAll(resp.Body)
 				resp.Body.Close()
 				break
 			}


### PR DESCRIPTION
a user asked why crng is not reusing the conns. when reading through the http client lib i saw this:

```
	// Body represents the response body.
	//
	// The response body is streamed on demand as the Body field
	// is read. If the network connection fails or the server
	// terminates the response, Body.Read calls return an error.
	//
	// The http Client and Transport guarantee that Body is always
	// non-nil, even on responses without a body or responses with
	// a zero-length body. It is the caller's responsibility to
	// close Body. The default HTTP client's Transport may not
	// reuse HTTP/1.x "keep-alive" TCP connections if the Body is
	// not read to completion and closed.
	//
	// The Body is automatically dechunked if the server replied
	// with a "chunked" Transfer-Encoding.
	Body io.ReadCloser
```

We currently do not seem to read that body before closing it