### PR TITLE
[WIP] bring up docker env in unit test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ jobs:
     working_directory: /go/src/github.com/graphite-ng/carbon-relay-ng
     docker:
       - image: circleci/golang:1.10.3
+      - image: rabbitmq
     steps:
       - checkout
       - run: go test -v -race ./...

--- a/stacktest/amqp/amqp_test.go
+++ b/stacktest/amqp/amqp_test.go
@@ -1,0 +1,65 @@
+package amqp
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// relativePath takes a relative path inside this repository and returns
+// the full path to the given destination
+func relativePath(dst string) string {
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		var err error
+		gopath, err = homedir.Expand("~/go")
+		if err != nil {
+			panic(err)
+		}
+	}
+	firstPath := strings.Split(gopath, ":")[0]
+	return p.Join(firstPath, "src/github.com/graphite-ng/carbon-relay-ng", dst)
+}
+
+func TestMain(m *testing.M) {
+	log.Println("launching docker-dev stack...")
+	version := exec.Command("docker-compose", "version")
+	output, err := version.CombinedOutput()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	log.Println(string(output))
+
+	cmd := exec.Command("docker-compose", "up", "--force-recreate")
+	cmd.Dir = relativePath("stacktest/amqp")
+
+	readPipe := func(in io.ReadCloser) {
+		scanner := bufio.NewScanner(in)
+		for scanner.Scan() {
+			// consume pipes, even if we don't look at the output
+		}
+	}
+
+	go readPipe(cmd.StdoutPipe())
+	go readPipe(cmd.StderrPipe())
+
+	err = cmd.Start()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	retcode := m.Run()
+
+	log.Println("stopping docker-compose stack...")
+	cmd.Process.Signal(syscall.SIGINT)
+	err = cmd.Wait()
+
+	// 130 means ctrl-C (interrupt) which is what we want
+	if err != nil && err.Error() != "exit status 130" {
+		log.Printf("ERROR: could not cleanly shutdown running docker-compose command: %s", err)
+		retcode = 1
+	} else {
+		log.Println("docker-compose stack is shut down")
+	}
+
+	os.Exit(retcode)
+}


### PR DESCRIPTION
Current status:
I have a local amqp server running in a docker container, using the public `rabbitmq` image. I'm trying to make `go test -race github.com/graphite-ng/carbon-relay-ng/input -test.v -run TestAmqpConsumeRabbit` connect to it, but I can't get it to succeed because the topic exchange doesn't exist and I can't find a way to create it with `rabbitmqctl`. I think if the unit test would connect to rabbitmq, then it could declare the topic exchange, and then the amqp input should succeed to connect on the next reconnect. So I think the next step should be to make the unit test connect and declare that exchange, and then verify that this way the input can connect successfully. 

Side Note: 
by default the `rabbitmq` image user the user `guest` with password `guest` for the virtualhost `/`. Alternatively users / vhosts can be created with these env vars:
```
RABBITMQ_DEFAULT_VHOST=vhost
RABBITMQ_DEFAULT_USER=test_user
RABBITMQ_DEFAULT_PASS=test_password
```