### PR TITLE
Fix init script and RPM build for CentOS 6

### DIFF
--- a/examples/c6-after-install.sh
+++ b/examples/c6-after-install.sh
@@ -1,0 +1,4 @@
+install -d -o carbon-relay-ng -g carbon-relay-ng -m 750 /var/log/carbon-relay-ng || true
+# On initial install, register service
+chkconfig --add carbon-relay-ng >/dev/null 2>&1 || true
+

--- a/examples/c6-after-upgrade.sh
+++ b/examples/c6-after-upgrade.sh
@@ -1,0 +1,3 @@
+# On upgrades, restart service if running
+service carbon-relay-ng condrestart >/dev/null 2>&1 || true
+

--- a/examples/c6-before-install.sh
+++ b/examples/c6-before-install.sh
@@ -1,0 +1,10 @@
+# Create a user and group for the daemon
+getent group  carbon-relay-ng >/dev/null 2>&1 \
+    || groupadd -r carbon-relay-ng >/dev/null 2>&1 \
+    || true
+getent passwd carbon-relay-ng >/dev/null 2>&1 \
+    || useradd  -g carbon-relay-ng -c "carbon-relay-ng" \
+        -d /var/lib/carbon-relay-ng -M -s /sbin/nologin -r \
+        carbon-relay-ng >/dev/null 2>&1 \
+    || true
+

--- a/examples/c6-before-remove.sh
+++ b/examples/c6-before-remove.sh
@@ -1,0 +1,4 @@
+# On removal, stop and un-register service
+service carbon-relay-ng stop    >/dev/null 2>&1 || true
+chkconfig --del carbon-relay-ng >/dev/null 2>&1 || true
+

--- a/examples/carbon-relay-ng.init
+++ b/examples/carbon-relay-ng.init
@@ -14,13 +14,15 @@
 
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 NAME=carbon-relay-ng
-DAEMON=/usr/local/bin/$NAME
+DAEMON=/usr/bin/$NAME
 PIDFILE=/var/run/carbon-relay-ng/$NAME.pid
-CONFFILE=/etc/carbon-relay-ng.ini
+CONFFILE=/etc/carbon-relay-ng/carbon-relay-ng.conf
 DAEMON_ARGS=$CONFFILE
-SCRIPTNAME=/etc/init.d/$NAME
 
-[ -x "$DAEMON" ] || exit 0
+if [ ! -x "$DAEMON" ]; then
+    echo >&2 "$(basename "$0"): $DAEMON not found"
+    exit 1
+fi
 
 [ -r /etc/default/${NAME} ] && . /etc/default/${NAME}
 
@@ -28,8 +30,7 @@ SCRIPTNAME=/etc/init.d/$NAME
 [ -z "$RELAY_GROUP" ] && RELAY_GROUP="carbon-relay-ng"
 [ -z "$LOG_DIR" ] && LOG_DIR="/var/log/carbon-relay-ng"
 
-. /lib/init/vars.sh
-
+. /etc/init.d/functions
 . /lib/lsb/init-functions
 
 if [ ! -r $CONFFILE ]; then
@@ -39,56 +40,77 @@ fi
 
 do_start()
 {
+    echo -n "Starting $NAME"
+    PIDDIR="$(dirname "$PIDFILE")"
+    if [ "$PIDDIR" = "/var/run" ]; then
+        echo >&2 "Error: PIDFILE must live in a subdirectory of /var/run"
+        log_msg 2
+        return
+    fi
+    mkdir -p "$PIDDIR"
+    chown $RELAY_USER "$PIDDIR"
 	start-stop-daemon --no-close -c $RELAY_USER -d /var/lib/carbon-relay-ng --background --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
 		$DAEMON_ARGS >${LOG_DIR}/carbon-relay-ng.log 2>&1 \
-		|| return 2
+		|| { log_msg 2; return; }
+    log_msg 0
 }
 
 do_stop()
 {
+    echo -n "Stopping $NAME"
 	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --name $NAME
-	RETVAL="$?"
-	[ "$RETVAL" = 2 ] && return 2
+	[ "$?" = 2 ] && { log_msg 2; return; }
 
 	start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $DAEMON
-	[ "$?" = 2 ] && return 2
+	[ "$?" = 2 ] && { log_msg 2; return; }
 
 	rm -f $PIDFILE
-	return "$RETVAL"
+    log_msg 0
 }
 
 do_reload() {
+    echo -n "Reloading $NAME"
 	start-stop-daemon --stop --quiet --pidfile $PIDFILE --signal USR2 --name $NAME
+    log_msg $?
+}
+
+log_msg() {
+    case "$1" in
+        0|1) echo_success ;;
+        2) echo_failure ;;
+    esac
+    echo
 }
 
 case "$1" in
-	start)
-	log_daemon_msg "Starting $NAME"
-	do_start
-	case "$?" in
-		0|1) log_end_msg 0 ;;
-		2) log_end_msg 1 ;;
-	esac
-	;;
-	stop)
-	log_daemon_msg "Stopping $NAME"
-	do_stop
-	case "$?" in
-		0|1) log_end_msg 0 ;;
-		2) log_end_msg 1 ;;
-	esac
-	;;
-	status)
-	status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
-	;;
-	restart|force-reload)
-	log_daemon_msg "Reloading $NAME"
-	do_reload
-	;;
-	*)
-	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
-	exit 3
-	;;
+    start)
+        do_start
+        ;;
+    stop)
+        do_stop
+        ;;
+    status)
+        status -b "$DAEMON" -p "$PIDFILE" && exit 0 || exit $?
+        ;;
+    restart)
+        do_stop
+        do_start
+        ;;
+    condrestart)
+        if ! status -b "$DAEMON" -p "$PIDFILE"; then
+            echo "Not running"
+            exit 0
+        fi
+        do_stop
+        do_start
+        ;;
+    force-reload)
+        do_reload
+        ;;
+    *)
+        echo "Usage: $(basename "$0") {start|stop|status|restart|condrestart|force-reload}" >&2
+        exit 3
+        ;;
 esac
 
 :


### PR DESCRIPTION
The RPM for CentOS 6 isn't very useful as is because it installs and init script that looks for the daemon in the wrong place (and thus exists silently without doing anything) and tries to source files that don't exist on CentOS 6, and it doesn't create an account for privilege separation nor the default directories for logs etc.

This fixes a lot of these issues using a few pre- and post-install RPM scripts and a basically rewritten init script.

I'm not completely happy with slapping everything in `examples/` and the way this isn't shared with the other RPM-based distributions so while I hope this will make it upstream I'd be happy to improve on it if anyone has suggestions.