### PR TITLE
Call pprof.StopCPUProfile before exit

### DIFF
--- a/cmd/carbon-relay-ng/carbon-relay-ng.go
+++ b/cmd/carbon-relay-ng/carbon-relay-ng.go
@@ -218,7 +218,6 @@ func main() {
 	if !manager.Stop(inputs, shutdownTimeout) {
 		os.Exit(1)
 	}
-	os.Exit(0)
 }
 
 func expandVars(in string) (out string) {


### PR DESCRIPTION
defer will not be run when using `os.Exit`
https://play.golang.org/p/CDiAh9SXRM