### PR TITLE
Add support for passing grafana.net credentials via environment variables

### DIFF
--- a/cmd/carbon-relay-ng/carbon-relay-ng.go
+++ b/cmd/carbon-relay-ng/carbon-relay-ng.go
@@ -6,9 +6,9 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"net"
 	_ "net/http/pprof"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"runtime"
@@ -58,7 +58,7 @@ func usage() {
 	flag.PrintDefaults()
 }
 
-func readConfigFile(config_file string) (string) {
+func readConfigFile(config_file string) string {
 	data, err := ioutil.ReadFile(config_file)
 	if err != nil {
 		log.Fatalf("Couldn't read config file %q: %s", config_file, err.Error())
@@ -85,7 +85,6 @@ func expandVars(in string) (out string) {
 		return ""
 	}
 }
-
 
 func main() {
 

--- a/cmd/carbon-relay-ng/carbon-relay-ng_test.go
+++ b/cmd/carbon-relay-ng/carbon-relay-ng_test.go
@@ -7,8 +7,8 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"io/ioutil"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -345,12 +345,10 @@ func TestConfigEnvVarInterpolation(t *testing.T) {
 	os.Setenv("GRAFANA_NET_ADDR", "foo.com")
 	os.Setenv("GRAFANA_NET_API_KEY", "wow")
 	os.Setenv("GRAFANA_NET_USER_ID", "123")
-	os.Setenv("HOST", "foo.bar.baz")
 
 	defer os.Unsetenv("GRAFANA_NET_ADDR")
 	defer os.Unsetenv("GRAFANA_NET_API_KEY")
 	defer os.Unsetenv("GRAFANA_NET_USER_ID")
-	defer os.Unsetenv("HOST")
 
 
 	template := []byte(`
@@ -362,14 +360,15 @@ addr = "${GRAFANA_NET_ADDR}"
 apikey = "${GRAFANA_NET_USER_ID}:${GRAFANA_NET_API_KEY}"
 `)
 
-	expected_template := `
-host = "work"
+	currentHostname, _  := os.Hostname()
+	expected_template := fmt.Sprintf(`
+host = "%s"
 # [[route]]
 key = 'grafanaNet'
 type = 'grafanaNet'
 addr = "foo.com"
 apikey = "123:wow"
-`
+`, currentHostname)
 
 	ioutil.WriteFile("/tmp/config.example.toml", template, 0644)
 	config := readConfigFile("/tmp/config.example.toml")

--- a/cmd/carbon-relay-ng/carbon-relay-ng_test.go
+++ b/cmd/carbon-relay-ng/carbon-relay-ng_test.go
@@ -8,6 +8,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"io/ioutil"
 	"sync"
 	"testing"
 	"time"
@@ -338,4 +339,42 @@ func BenchmarkTableDisPatchAndEndpointReceive(b *testing.B) {
 		b.Fatal(err)
 	}
 	tE.Close()
+}
+
+func TestConfigEnvVarInterpolation(t *testing.T) {
+	os.Setenv("GRAFANA_NET_ADDR", "foo.com")
+	os.Setenv("GRAFANA_NET_API_KEY", "wow")
+	os.Setenv("GRAFANA_NET_USER_ID", "123")
+	os.Setenv("HOST", "foo.bar.baz")
+
+	defer os.Unsetenv("GRAFANA_NET_ADDR")
+	defer os.Unsetenv("GRAFANA_NET_API_KEY")
+	defer os.Unsetenv("GRAFANA_NET_USER_ID")
+	defer os.Unsetenv("HOST")
+
+
+	template := []byte(`
+host = "${HOST}"
+# [[route]]
+key = 'grafanaNet'
+type = 'grafanaNet'
+addr = "${GRAFANA_NET_ADDR}"
+apikey = "${GRAFANA_NET_USER_ID}:${GRAFANA_NET_API_KEY}"
+`)
+
+	expected_template := `
+host = "work"
+# [[route]]
+key = 'grafanaNet'
+type = 'grafanaNet'
+addr = "foo.com"
+apikey = "123:wow"
+`
+
+	ioutil.WriteFile("/tmp/config.example.toml", template, 0644)
+	config := readConfigFile("/tmp/config.example.toml")
+
+	if config != expected_template {
+		t.Errorf("Expected interpolated config %s but got %s", expected_template, config)
+	}
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -68,7 +68,7 @@ max = -1
 
 ## carbon route
 
-setting        | mandatory | values                                        | default | description 
+setting        | mandatory | values                                        | default | description
 ---------------|-----------|-----------------------------------------------|---------|------------
 key            |     Y     | string                                        | N/A     |
 type           |     Y     | sendAllMatch/sendFirstMatch/consistentHashing | N/A     | send to all destinations vs first matching destination vs distribute via consistent hashing
@@ -112,7 +112,7 @@ destinations = [
 
 ## carbon destination
 
-setting              | mandatory | values        | default | description 
+setting              | mandatory | values        | default | description
 ---------------------|-----------|---------------|---------|------------
 addr                 |     Y     |  string       | N/A     |
 prefix               |     N     |  string       | ""      |
@@ -133,7 +133,7 @@ unspoolsleep         |     N     |  int (micros) | 10      | sleep this many mic
 
 ## grafanaNet route
 
-setting        | mandatory | values      | default | description 
+setting        | mandatory | values      | default | description
 ---------------|-----------|-------------|---------|------------
 key            |     Y     |  string     | N/A     |
 addr           |     Y     |  string     | N/A     |
@@ -178,9 +178,18 @@ schemasFile = 'examples/storage-schemas.conf'
 concurrency=100
 ```
 
+example config with credentials coming from the environment variables
+
+```
+key = 'grafanaNet'
+type = 'grafanaNet'
+addr = "${GRAFANA_NET_ADDR}"
+apikey = "${GRAFANA_NET_USER_ID}:${GRAFANA_NET_API_KEY}"
+```
+
 ## kafkaMdm route
 
-setting        | mandatory | values      | default | description 
+setting        | mandatory | values      | default | description
 ---------------|-----------|-------------|---------|------------
 key            |     Y     |  string     | N/A     |
 brokers        |     Y     |  []string   | N/A     | host:port addresses (if specified as init command or over tcp interface: comma separated)
@@ -200,7 +209,7 @@ orgId          |     N     |  int        | 1       |
 
 ## Google PubSub route
 
-setting        | mandatory | values      | default       | description 
+setting        | mandatory | values      | default       | description
 ---------------|-----------|-------------|---------------|------------
 key            |     Y     |  string     | N/A           |
 project        |     Y     |  string     | N/A           | Google Cloud Project containing the topic
@@ -216,7 +225,7 @@ flushMaxWait   |     N     |  int (ms)   | 1000          | max time to buffer be
 
 ## Cloudwatch
 
-setting          | mandatory | values      | default       | description 
+setting          | mandatory | values      | default       | description
 -----------------|-----------|-------------|---------------|------------
 key              |     Y     |  string     | N/A           |
 profile          |     N     |  string     | N/A           | The Amazon CloudWatch profile to use. For local development needed only. In the cloud, the profile is known.


### PR DESCRIPTION
It doesn't expose all config options to be set via env vars, like here: https://github.com/grafana/carbon-relay-ng/issues/192 but helps with configuring grafana.net route at least.

I've extracted how the config file is read, so there is a centralized place for adding support for more environment variables. Technically, I could have used [`os.ExpandEnv`](https://golang.org/pkg/os/#ExpandEnv) but it didn't work in tests and might be a bit too flexible. On the other hand it would allow specifying multiple credentials for the same type of a route, e.g. using variables like `GRAFANA_1_API_KEY` etc.

It's been a while since I wrote any Go code - please let me know if I need to fix anything 👍 
