### PR TITLE
fix kafka partitioner

### DIFF
--- a/route/kafkamdm.go
+++ b/route/kafkamdm.go
@@ -111,6 +111,7 @@ func NewKafkaMdm(key, prefix, sub, regex, topic, codec, schemasFile, partitionBy
 	}
 	config.Producer.Return.Successes = true
 	config.Producer.Timeout = time.Duration(timeout) * time.Millisecond
+	config.Producer.Partitioner = sarama.NewManualPartitioner
 	err = config.Validate()
 	if err != nil {
 		log.Fatalf("kafkaMdm %q: failed to validate kafka config. %s", r.key, err)


### PR DESCRIPTION
fixes: #396 

by setting the producer to "manual partitioner" the `.Partition` property which gets set in the message producing code gets used as the kafka partition:

https://godoc.org/github.com/Shopify/sarama#NewManualPartitioner

I confirmed by tcpdump & wireshark that this fixes the described issue
