### PR TITLE
Ensure that capture groups are preserved for #399.

### DIFF
--- a/cmd/carbon-relay-ng/carbon-relay-ng.go
+++ b/cmd/carbon-relay-ng/carbon-relay-ng.go
@@ -82,7 +82,7 @@ func expandVars(in string) (out string) {
 	case "GRAFANA_NET_USER_ID":
 		return os.Getenv("GRAFANA_NET_USER_ID")
 	default:
-		return ""
+		return "$" + in
 	}
 }
 

--- a/cmd/carbon-relay-ng/carbon-relay-ng_test.go
+++ b/cmd/carbon-relay-ng/carbon-relay-ng_test.go
@@ -391,3 +391,17 @@ apikey = "123:wow"
 		t.Errorf("Expected interpolated config %s but got %s", expected_template, config)
 	}
 }
+
+func TestConfigDontInterpolateOtherValues(t *testing.T) {
+	template := []byte(`
+regex = '^servers\.(dc[0-9]+)\.(app|proxy)[0-9]+\.(.*)'
+format = 'aggregates.$1.$2.$3.sum'`)
+
+
+	ioutil.WriteFile("/tmp/config.example.toml", template, 0644)
+	config := readConfigFile("/tmp/config.example.toml")
+
+	if config != string(template) {
+		t.Errorf("Expected interpolated config to be unchanged")
+	}
+}


### PR DESCRIPTION
Fixes an issue introduced in #393.

As described in #399 , if a regex capture group is used in the config, our variable expansion currently removes it.

This PR adds the capture group back in by making the default case of our `os.Expand` function return `$<input>`.  Note that we would still have a similar issue occur if we ever had a string of the form `${<something>}` in the config (it would return `$<something>`)