### PR TITLE
Force enabled modules in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION=$(shell git describe --tags --always | sed 's/^v//')
-
+export GO111MODULE := on
 
 build:
 	cd ui/web && go-bindata -pkg web admin_http_assets/...


### PR DESCRIPTION
- It appears that in CircleCI the modules are not on by default.
  https://circleci.com/gh/grafana/carbon-relay-ng/1090