### PR TITLE
Switch CircleCI Test to use make.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       - image: circleci/golang:1.12
     steps:
       - checkout
-      - run: go test -v -race ./...
+      - run: make test
 
   build:
     working_directory: /go/src/github.com/grafana/carbon-relay-ng

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ carbon-relay-ng:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-X main.Version=$(VERSION)" ./cmd/carbon-relay-ng
 
 test:
-	go test ./...
+	go test -v -race ./...
 
 docker: build-linux
 	./build_docker.sh


### PR DESCRIPTION
- The makefile sets variables for gomodules so that dependency resolution works.

@Dieterbe should be the last one :sweat: 