### PR TITLE
Initial support for pushing docker images to grafana org

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,12 +81,18 @@ jobs:
 
                docker load -i build/carbon-relay-ng.tar
                docker login -u $DOCKER_USER -p $DOCKER_KEY
+
+               # push to both raintank and grafana orgs for now, switch to just grafana at some point in the future
                docker push raintank/carbon-relay-ng:$version
+               docker push grafana/carbon-relay-ng:$version
                # only versions without a hyphen - e.g. actual releases - are tagged as latest.
                # in-between-release versions are tagged as master.
                tag=latest
                [[ "$version" == *-* ]] && tag=master
+
+                # push to both raintank and grafana orgs for now, switch to just grafana at some point in the future
                docker push raintank/carbon-relay-ng:$tag
+               docker push grafana/carbon-relay-ng:$tag
             fi
 workflows:
   version: 2

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -8,5 +8,8 @@ tag=master
 grep -q "master" .git/HEAD && [[ "$version" != *-* ]] && tag=latest
 
 
+# push to both raintank and grafana orgs for now, switch to just grafana at some point in the future
 docker build --tag=raintank/carbon-relay-ng:$tag .
 docker tag raintank/carbon-relay-ng:$tag raintank/carbon-relay-ng:$version
+docker tag raintank/carbon-relay-ng:$tag grafana/carbon-relay-ng:$tag
+docker tag raintank/carbon-relay-ng:$tag grafana/carbon-relay-ng:version


### PR DESCRIPTION
(Maybe) pushes docker images to both the raintank and grafana orgs as requested in https://github.com/grafana/carbon-relay-ng/issues/414.

Not sure if this will actually work (are the creds the same?), so I haven't updated documentation yet.

My current plan:
* merge to master
* see if it publishes docker images
  * if it works, update docs and add documentation in subsequent PR.
  * if it doesn't, roll back and figure out next steps