### PR TITLE
Create binaries for linux, mac, and windows, and update release docs to attach them to the release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,14 @@ jobs:
       # so for now, we just let it slip and assume devs will do a good enough job maintaining the generated data
       # - git diff --exit-code
       - run: make build-win
+      - run: make build-darwin
       - persist_to_workspace:
           root: .
           paths:
             - carbon-relay-ng
             - carbon-relay-ng.exe
+            - carbon-relay-ng-darwin
+            - carbon-relay-ng-linux
 
   package:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,20 @@ carbon-relay-ng.exe:
 	find . -name '*.go' | grep -v '^\.\/vendor' | xargs gofmt -w -s
 	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-X main.Version=$(VERSION)" -o carbon-relay-ng.exe ./cmd/carbon-relay-ng
 
+build-darwin: carbon-relay-ng-darwin
+
+carbon-relay-ng-darwin:
+	cd ui/web && go-bindata -pkg web admin_http_assets/...
+	find . -name '*.go' | grep -v '^\.\/vendor' | xargs gofmt -w -s
+	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-X main.Version=$(VERSION)" -o carbon-relay-ng-darwin ./cmd/carbon-relay-ng
+
 build-linux: carbon-relay-ng
 
 carbon-relay-ng:
 	cd ui/web && go-bindata -pkg web admin_http_assets/...
 	find . -name '*.go' | grep -v '^\.\/vendor' | xargs gofmt -w -s
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-X main.Version=$(VERSION)" ./cmd/carbon-relay-ng
+	cp carbon-relay-ng carbon-relay-ng-linux
 
 test:
 	go test -v -race ./...

--- a/docs/installation-building.md
+++ b/docs/installation-building.md
@@ -17,9 +17,9 @@ See the installation instructions on those pages for how to enable the repositor
 
 We host packages for Ubuntu 14.04 (trusty), 16.04 (xenial), debian 8, 9, 10 (jessie, stretch and buster/testing), Centos6 and Centos7.
 
-## Windows
+## Binaries
 
-For Windows users, see the included executables along with the release on the [releases](https://github.com/grafana/carbon-relay-ng/releases) page.
+Executable Binaries for Linux, Mac, and Windows can be found on the [releases](https://github.com/grafana/carbon-relay-ng/releases) page (starting with v0.13.0) .
 
 ## Docker images
 
@@ -77,4 +77,4 @@ When interesting changes have been merged to master, and they have had a chance 
 * create annotated git tag in the form `v<version>` and push to GitHub
 * wait for CircleCI to complete successfully.
 * create release on GitHub. copy entry from CHANGELOG.md to GitHub release page
-* upload windows build from CircleCI to the release as well.
+* upload platform specific binaries from CircleCI to the release as well.


### PR DESCRIPTION
Currently binaries are only included for windows.

This PR updates the release builds to generate binaries for all 3 major platforms, and updates the release docs to include them with the release.