### PR TITLE
fix aggregator benchmarks

### DIFF
--- a/aggregator/aggregator_test.go
+++ b/aggregator/aggregator_test.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/grafana/carbon-relay-ng/util"
 )
 
 func TestScanner(t *testing.T) {
@@ -220,6 +222,9 @@ func BenchmarkAggregator5Aggregates100PointsPerAggregateWithReCache(b *testing.B
 
 func benchmarkAggregator(aggregates, pointsPerAggregate int, match string, cache bool, b *testing.B) {
 	//fmt.Println("BenchmarkAggregator", aggregates, pointsPerAggregate, "with b.N", b.N)
+	InitMetrics()
+	flushes = util.NewLimiter(1)
+
 	out := make(chan []byte)
 	done := make(chan struct{})
 	go func(match string) {


### PR DESCRIPTION
There were 2 issues with the benchmarks:

1) panic because the aggmetric package metrics were not initialized
2) it got stuck because the limiter was not initialized