### PR TITLE
Inverted filter criteria for matchers (simplified)

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -223,7 +223,7 @@ func (a *Aggregator) Shutdown() {
 }
 
 func (a *Aggregator) AddMaybe(buf [][]byte, val float64, ts uint32) bool {
-	if !a.Matcher.MatchAllExceptRegex(buf[0]) {
+	if !a.Matcher.PreMatch(buf[0]) {
 		return false
 	}
 

--- a/aggregator/aggregator_test.go
+++ b/aggregator/aggregator_test.go
@@ -303,7 +303,7 @@ func benchmarkAggregator(aggregates, pointsPerAggregate int, match string, cache
 	clock.AddTick(tick)
 	bufSize := 2 * aggregates * pointsPerAggregate
 
-	agg, err := NewMocked("sum", regex, "", "", outFmt, cache, 10, 30, false, out, bufSize, clock.Now, tick.C)
+	agg, err := NewMocked("sum", regex, "", "", "", "", "", outFmt, cache, 10, 30, false, out, bufSize, clock.Now, tick.C)
 	if err != nil {
 		b.Fatalf("couldn't create aggregation: %q", err)
 	}

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -57,23 +57,29 @@ func (d *Duration) UnmarshalText(text []byte) error {
 }
 
 type Aggregation struct {
-	Function string
-	Regex    string
-	Prefix   string
-	Substr   string
-	Format   string
-	Cache    bool
-	Interval int
-	Wait     int
-	DropRaw  bool
+	Function  string
+	Regex     string
+	NotRegex  string
+	Prefix    string
+	NotPrefix string
+	Substr    string
+	NotSubstr string
+	Format    string
+	Cache     bool
+	Interval  int
+	Wait      int
+	DropRaw   bool
 }
 
 type Route struct {
 	Key          string
 	Type         string
 	Prefix       string
+	NotPrefix    string
 	Substr       string
+	NotSubstr    string
 	Regex        string
+	NotRegex     string
 	Destinations []string
 
 	// grafanaNet & kafkaMdm & Google PubSub

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -69,8 +69,8 @@ type Destination struct {
 }
 
 // New creates a destination object. Note that it still needs to be told to run via Run().
-func New(routeName, prefix, sub, regex, addr, spoolDir string, spool, pickle bool, periodFlush, periodReConn time.Duration, connBufSize, ioBufSize, spoolBufSize int, spoolMaxBytesPerFile, spoolSyncEvery int64, spoolSyncPeriod, spoolSleep, unspoolSleep time.Duration) (*Destination, error) {
-	m, err := matcher.New(prefix, sub, regex)
+func New(routeName, prefix, notPrefix, sub, notSub, regex, notRegex, addr, spoolDir string, spool, pickle bool, periodFlush, periodReConn time.Duration, connBufSize, ioBufSize, spoolBufSize int, spoolMaxBytesPerFile, spoolSyncEvery int64, spoolSyncPeriod, spoolSleep, unspoolSleep time.Duration) (*Destination, error) {
+	m, err := matcher.New(prefix, notPrefix, sub, notSub, regex, notRegex)
 	if err != nil {
 		return nil, err
 	}
@@ -116,8 +116,11 @@ func (dest *Destination) Match(s []byte) bool {
 func (dest *Destination) Update(opts map[string]string) error {
 	match := dest.GetMatcher()
 	prefix := match.Prefix
+	notPrefix := match.NotPrefix
 	sub := match.Sub
+	notSub := match.NotSub
 	regex := match.Regex
+	notRegex := match.NotRegex
 	updateMatcher := false
 	addr := ""
 
@@ -128,11 +131,20 @@ func (dest *Destination) Update(opts map[string]string) error {
 		case "prefix":
 			prefix = val
 			updateMatcher = true
+		case "notPrefix":
+			notPrefix = val
+			updateMatcher = true
 		case "sub":
 			sub = val
 			updateMatcher = true
+		case "notSub":
+			notSub = val
+			updateMatcher = true
 		case "regex":
 			regex = val
+			updateMatcher = true
+		case "notRegex":
+			notRegex = val
 			updateMatcher = true
 		default:
 			return errors.New("no such option: " + name)
@@ -142,7 +154,7 @@ func (dest *Destination) Update(opts map[string]string) error {
 		dest.updateConn(addr)
 	}
 	if updateMatcher {
-		match, err := matcher.New(prefix, sub, regex)
+		match, err := matcher.New(prefix, notPrefix, sub, notSub, regex, notRegex)
 		if err != nil {
 			return err
 		}

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -69,15 +69,11 @@ type Destination struct {
 }
 
 // New creates a destination object. Note that it still needs to be told to run via Run().
-func New(routeName, prefix, notPrefix, sub, notSub, regex, notRegex, addr, spoolDir string, spool, pickle bool, periodFlush, periodReConn time.Duration, connBufSize, ioBufSize, spoolBufSize int, spoolMaxBytesPerFile, spoolSyncEvery int64, spoolSyncPeriod, spoolSleep, unspoolSleep time.Duration) (*Destination, error) {
-	m, err := matcher.New(prefix, notPrefix, sub, notSub, regex, notRegex)
-	if err != nil {
-		return nil, err
-	}
+func New(routeName string, matcher matcher.Matcher, addr, spoolDir string, spool, pickle bool, periodFlush, periodReConn time.Duration, connBufSize, ioBufSize, spoolBufSize int, spoolMaxBytesPerFile, spoolSyncEvery int64, spoolSyncPeriod, spoolSleep, unspoolSleep time.Duration) (*Destination, error) {
 	key := util.Key(routeName, addr)
 	addr, instance := addrInstanceSplit(addr)
 	dest := &Destination{
-		Matcher:              *m,
+		Matcher:              matcher,
 		Addr:                 addr,
 		Instance:             instance,
 		SpoolDir:             spoolDir,
@@ -158,7 +154,7 @@ func (dest *Destination) Update(opts map[string]string) error {
 		if err != nil {
 			return err
 		}
-		dest.UpdateMatcher(*match)
+		dest.UpdateMatcher(match)
 	}
 	return nil
 }

--- a/imperatives/imperatives.go
+++ b/imperatives/imperatives.go
@@ -899,16 +899,31 @@ func readModDest(s *toki.Scanner, table Table) error {
 				return errFmtModDest
 			}
 			opts["prefix"] = string(t.Value)
+		case optNotPrefix:
+			if t = s.Next(); t.Token != word {
+				return errFmtModDest
+			}
+			opts["notPrefix"] = string(t.Value)
 		case optSub:
 			if t = s.Next(); t.Token != word {
 				return errFmtModDest
 			}
 			opts["sub"] = string(t.Value)
+		case optNotSub:
+			if t = s.Next(); t.Token != word {
+				return errFmtModDest
+			}
+			opts["notSub"] = string(t.Value)
 		case optRegex:
 			if t = s.Next(); t.Token != word {
 				return errFmtModDest
 			}
 			opts["regex"] = string(t.Value)
+		case optNotRegex:
+			if t = s.Next(); t.Token != word {
+				return errFmtModDest
+			}
+			opts["notRegex"] = string(t.Value)
 		default:
 			return errFmtModDest
 		}
@@ -938,16 +953,31 @@ func readModRoute(s *toki.Scanner, table Table) error {
 				return errFmtModDest
 			}
 			opts["prefix"] = string(t.Value)
+		case optNotPrefix:
+			if t = s.Next(); t.Token != word {
+				return errFmtModDest
+			}
+			opts["notPrefix"] = string(t.Value)
 		case optSub:
 			if t = s.Next(); t.Token != word {
 				return errFmtModDest
 			}
 			opts["sub"] = string(t.Value)
+		case optNotSub:
+			if t = s.Next(); t.Token != word {
+				return errFmtModDest
+			}
+			opts["notSub"] = string(t.Value)
 		case optRegex:
 			if t = s.Next(); t.Token != word {
 				return errFmtModDest
 			}
 			opts["regex"] = string(t.Value)
+		case optNotRegex:
+			if t = s.Next(); t.Token != word {
+				return errFmtModDest
+			}
+			opts["notRegex"] = string(t.Value)
 		default:
 			return errFmtModDest
 		}

--- a/imperatives/imperatives_test.go
+++ b/imperatives/imperatives_test.go
@@ -1,9 +1,10 @@
 package imperatives
 
 import (
-	"github.com/taylorchu/toki"
 	"strings"
 	"testing"
+
+	"github.com/taylorchu/toki"
 )
 
 func TestScanner(t *testing.T) {
@@ -38,6 +39,10 @@ func TestScanner(t *testing.T) {
 		{
 			"addRoute sendFirstMatch analytics regex=(Err/s|wait_time|logger)  graphite.prod:2003 prefix=prod. spool=true pickle=true  graphite.staging:2003 prefix=staging. spool=true pickle=true",
 			[]toki.Token{addRouteSendFirstMatch, word, optRegex, word, sep, word, optPrefix, word, optSpool, optTrue, optPickle, optTrue, sep, word, optPrefix, word, optSpool, optTrue, optPickle, optTrue},
+		},
+		{
+			"addRoute sendFirstMatch myRoute1  127.0.0.1:2003 notPrefix=aaa notSub=bbb notRegex=ccc",
+			[]toki.Token{addRouteSendFirstMatch, word, sep, word, optNotPrefix, word, optNotSub, word, optNotRegex, word},
 		},
 		//{ disabled cause tries to read the schemas.conf file
 		//	"addRoute grafanaNet grafanaNet  http://localhost:8081/metrics your-grafana.net-api-key /path/to/storage-schemas.conf",

--- a/imperatives/mocktable_test.go
+++ b/imperatives/mocktable_test.go
@@ -10,12 +10,14 @@ import (
 type mockTable struct {
 }
 
-func (m *mockTable) AddAggregator(agg *aggregator.Aggregator)                              {}
-func (m *mockTable) AddRewriter(rw rewriter.RW)                                            {}
-func (m *mockTable) AddBlacklist(matcher *matcher.Matcher)                                 {}
-func (m *mockTable) AddRoute(route route.Route)                                            {}
-func (m *mockTable) DelRoute(key string) error                                             { return nil }
-func (m *mockTable) UpdateDestination(key string, index int, opts map[string]string) error { return nil }
-func (m *mockTable) UpdateRoute(key string, opts map[string]string) error                  { return nil }
-func (m *mockTable) GetIn() chan []byte                                                    { return nil }
-func (m *mockTable) GetSpoolDir() string                                                   { return "fake-spool-dir" }
+func (m *mockTable) AddAggregator(agg *aggregator.Aggregator) {}
+func (m *mockTable) AddRewriter(rw rewriter.RW)               {}
+func (m *mockTable) AddBlacklist(matcher *matcher.Matcher)    {}
+func (m *mockTable) AddRoute(route route.Route)               {}
+func (m *mockTable) DelRoute(key string) error                { return nil }
+func (m *mockTable) UpdateDestination(key string, index int, opts map[string]string) error {
+	return nil
+}
+func (m *mockTable) UpdateRoute(key string, opts map[string]string) error { return nil }
+func (m *mockTable) GetIn() chan []byte                                   { return nil }
+func (m *mockTable) GetSpoolDir() string                                  { return "fake-spool-dir" }

--- a/matcher/matcher.go
+++ b/matcher/matcher.go
@@ -31,8 +31,11 @@ type matcherFuncs []matcherFunc
 func (m matcherFuncs) singleMatcherFunc() matcherFunc {
 	switch len(m) {
 	case 0:
+		// when no filter is defined we just let everything pass
 		return func(_ []byte) bool { return true }
 	case 1:
+		// when there is only one element in matcherFuncs we can directly return
+		// it and save the overhead of having to wrap another function around it
 		return m[0]
 	default:
 		return func(s []byte) bool {
@@ -66,6 +69,12 @@ func (m *Matcher) String() string {
 	return fmt.Sprintf("<Matcher. prefix:%q, notPrefix:%q, sub: %q, notSub: %q, regex: %q, notRegex:%q>", m.Prefix, m.NotPrefix, m.Sub, m.NotSub, m.Regex, m.NotRegex)
 }
 
+// updateInternals checks which filters this matcher should use and generates a
+// filter function for each of them.
+// Then it combines all these filter functions into one function
+// which it assigns to Matcher.Match.
+// Furthermore, it combines all filter functions except the "regex" filter into
+// another single filter function and assigns it to Matcher.MatchAllExceptRegex.
 func (m *Matcher) updateInternals() error {
 	m.prefix = []byte(m.Prefix)
 	m.notPrefix = []byte(m.NotPrefix)

--- a/matcher/matcher.go
+++ b/matcher/matcher.go
@@ -7,19 +7,25 @@ import (
 )
 
 type Matcher struct {
-	Prefix string `json:"prefix,omitempty"`
-	Sub    string `json:"substring,omitempty"`
-	Regex  string `json:"regex,omitempty"`
+	Prefix    string `json:"prefix,omitempty"`
+	NotPrefix string `json:"notPrefix,omitempty"`
+	Sub       string `json:"substring,omitempty"`
+	NotSub    string `json:"notSubstring,omitempty"`
+	Regex     string `json:"regex,omitempty"`
+	NotRegex  string `json:"notRegex,omitempty"`
 	// internal representation for performance optimalization
-	prefix, substring []byte
-	regex             *regexp.Regexp // compiled version of Regex
+	prefix, notPrefix, substring, notSubstring []byte
+	regex, notRegex                            *regexp.Regexp // compiled version of Regex
 }
 
-func New(prefix, sub, regex string) (*Matcher, error) {
+func New(prefix, notPrefix, sub, notSub, regex, notRegex string) (*Matcher, error) {
 	match := new(Matcher)
 	match.Prefix = prefix
+	match.NotPrefix = notPrefix
 	match.Sub = sub
+	match.NotSub = notSub
 	match.Regex = regex
+	match.NotRegex = notRegex
 	err := match.updateInternals()
 	if err != nil {
 		return nil, err
@@ -33,13 +39,22 @@ func (m *Matcher) String() string {
 
 func (m *Matcher) updateInternals() error {
 	m.prefix = []byte(m.Prefix)
+	m.notPrefix = []byte(m.notPrefix)
 	m.substring = []byte(m.Sub)
+	m.notSubstring = []byte(m.notSubstring)
 	if len(m.Regex) > 0 {
 		regexObj, err := regexp.Compile(m.Regex)
 		if err != nil {
 			return err
 		}
 		m.regex = regexObj
+	}
+	if len(m.NotRegex) > 0 {
+		regexObj, err := regexp.Compile(m.NotRegex)
+		if err != nil {
+			return err
+		}
+		m.notRegex = regexObj
 	}
 	return nil
 }
@@ -48,10 +63,19 @@ func (m *Matcher) Match(s []byte) bool {
 	if len(m.prefix) > 0 && !bytes.HasPrefix(s, m.prefix) {
 		return false
 	}
+	if len(m.notPrefix) > 0 && bytes.HasPrefix(s, m.notPrefix) {
+		return false
+	}
 	if len(m.substring) > 0 && !bytes.Contains(s, m.substring) {
 		return false
 	}
+	if len(m.notSubstring) > 0 && bytes.Contains(s, m.notSubstring) {
+		return false
+	}
 	if m.regex != nil && !m.regex.Match(s) {
+		return false
+	}
+	if m.notRegex != nil && m.notRegex.Match(s) {
 		return false
 	}
 	return true

--- a/matcher/matcher.go
+++ b/matcher/matcher.go
@@ -14,40 +14,43 @@ type Matcher struct {
 	Regex     string `json:"regex,omitempty"`
 	NotRegex  string `json:"notRegex,omitempty"`
 	// internal representation for performance optimalization
-	prefix, notPrefix, substring, notSubstring []byte
-	regex, notRegex                            *regexp.Regexp // compiled version of Regex
+	prefix, notPrefix, sub, notSub, prefixFromRegex []byte
+	// compiled version of Regex
+	regex, notRegex *regexp.Regexp
 }
 
-func New(prefix, notPrefix, sub, notSub, regex, notRegex string) (*Matcher, error) {
-	match := new(Matcher)
-	match.Prefix = prefix
-	match.NotPrefix = notPrefix
-	match.Sub = sub
-	match.NotSub = notSub
-	match.Regex = regex
-	match.NotRegex = notRegex
+func New(prefix, notPrefix, sub, notSub, regex, notRegex string) (Matcher, error) {
+	match := Matcher{
+		Prefix:    prefix,
+		NotPrefix: notPrefix,
+		Sub:       sub,
+		NotSub:    notSub,
+		Regex:     regex,
+		NotRegex:  notRegex,
+	}
 	err := match.updateInternals()
 	if err != nil {
-		return nil, err
+		return match, err
 	}
 	return match, nil
 }
 
 func (m *Matcher) String() string {
-	return fmt.Sprintf("<Matcher. prefix:%q, sub: %q, regex: %q>", m.Prefix, m.Sub, m.Regex)
+	return fmt.Sprintf("<Matcher. prefix:%q, notPrefix:%q, sub: %q, notSub: %q, regex: %q, notRegex:%q>", m.Prefix, m.NotPrefix, m.Sub, m.NotSub, m.Regex, m.NotRegex)
 }
 
 func (m *Matcher) updateInternals() error {
 	m.prefix = []byte(m.Prefix)
-	m.notPrefix = []byte(m.notPrefix)
-	m.substring = []byte(m.Sub)
-	m.notSubstring = []byte(m.notSubstring)
+	m.notPrefix = []byte(m.NotPrefix)
+	m.sub = []byte(m.Sub)
+	m.notSub = []byte(m.NotSub)
 	if len(m.Regex) > 0 {
 		regexObj, err := regexp.Compile(m.Regex)
 		if err != nil {
 			return err
 		}
 		m.regex = regexObj
+		m.prefixFromRegex = regexToPrefix(m.Regex)
 	}
 	if len(m.NotRegex) > 0 {
 		regexObj, err := regexp.Compile(m.NotRegex)
@@ -59,6 +62,7 @@ func (m *Matcher) updateInternals() error {
 	return nil
 }
 
+// Match matches the given byte slice against all filter conditions
 func (m *Matcher) Match(s []byte) bool {
 	if len(m.prefix) > 0 && !bytes.HasPrefix(s, m.prefix) {
 		return false
@@ -66,17 +70,82 @@ func (m *Matcher) Match(s []byte) bool {
 	if len(m.notPrefix) > 0 && bytes.HasPrefix(s, m.notPrefix) {
 		return false
 	}
-	if len(m.substring) > 0 && !bytes.Contains(s, m.substring) {
+	if len(m.sub) > 0 && !bytes.Contains(s, m.sub) {
 		return false
 	}
-	if len(m.notSubstring) > 0 && bytes.Contains(s, m.notSubstring) {
+	if len(m.notSub) > 0 && bytes.Contains(s, m.notSub) {
 		return false
 	}
-	if m.regex != nil && !m.regex.Match(s) {
+	if m.regex != nil {
+		if len(m.prefixFromRegex) > 0 && bytes.HasPrefix(s, m.prefixFromRegex) {
+			return false
+		}
+		if !m.regex.Match(s) {
+			return false
+		}
+	}
+	if m.notRegex != nil && m.notRegex.Match(s) {
+		return false
+	}
+	return true
+}
+
+// MatchAll matches the given byte slice against all filter conditions except "regex"
+func (m *Matcher) MatchAllExceptRegex(s []byte) bool {
+	if len(m.prefix) > 0 && !bytes.HasPrefix(s, m.prefix) {
+		return false
+	}
+	if len(m.notPrefix) > 0 && bytes.HasPrefix(s, m.notPrefix) {
+		return false
+	}
+	if len(m.sub) > 0 && !bytes.Contains(s, m.sub) {
+		return false
+	}
+	if len(m.notSub) > 0 && bytes.Contains(s, m.notSub) {
+		return false
+	}
+	if len(m.prefixFromRegex) > 0 && bytes.HasPrefix(s, m.prefixFromRegex) {
 		return false
 	}
 	if m.notRegex != nil && m.notRegex.Match(s) {
 		return false
 	}
 	return true
+}
+
+func (m *Matcher) MatchRegexAndExpand(key, fmt []byte) (string, bool) {
+	var dst []byte
+	matches := m.regex.FindSubmatchIndex(key)
+	if matches == nil {
+		return "", false
+	}
+	return string(m.regex.Expand(dst, fmt, key, matches)), true
+}
+
+// regexToPrefix inspects the regex and returns the longest static prefix part of the regex
+// all inputs for which the regex match, must have this prefix
+func regexToPrefix(regex string) []byte {
+	substr := ""
+	for i := 0; i < len(regex); i++ {
+		ch := regex[i]
+		if i == 0 {
+			if ch == '^' {
+				continue // good we need this
+			} else {
+				break // can't deduce any substring here
+			}
+		}
+		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_' || ch == '-' {
+			substr += string(ch)
+			// "\." means a dot character
+		} else if ch == 92 && i+1 < len(regex) && regex[i+1] == '.' {
+			substr += "."
+			i += 1
+		} else {
+			//fmt.Println("don't know what to do with", string(ch))
+			// anything more advanced should be regex syntax that is more permissive and hence not a static substring.
+			break
+		}
+	}
+	return []byte(substr)
 }

--- a/matcher/matcher.go
+++ b/matcher/matcher.go
@@ -18,8 +18,8 @@ type Matcher struct {
 	// compiled version of Regex
 	regex, notRegex *regexp.Regexp
 
-	Match               matcherFunc
-	MatchAllExceptRegex matcherFunc
+	Match               matcherFunc `json:"-"`
+	MatchAllExceptRegex matcherFunc `json:"-"`
 }
 
 type matcherFunc func([]byte) bool

--- a/matcher/matcher.go
+++ b/matcher/matcher.go
@@ -34,13 +34,7 @@ func (m matcherFuncs) singleMatcherFunc() matcherFunc {
 		return func(_ []byte) bool { return true }
 	case 1:
 		return m[0]
-	case 2:
-		return func(s []byte) bool { return m[0](s) && m[1](s) }
-	case 3:
-		return func(s []byte) bool { return m[0](s) && m[1](s) && m[2](s) }
 	default:
-		// more than 3 matchers seems like an edge case,
-		// so we take the hit of doing an allocation
 		return func(s []byte) bool {
 			for _, matcherFunc := range m {
 				if !matcherFunc(s) {

--- a/matcher/matcher_test.go
+++ b/matcher/matcher_test.go
@@ -410,3 +410,19 @@ func BenchmarkMatchRegex(b *testing.B) {
 		matcher.Match(metric70)
 	}
 }
+
+func BenchmarkMatch3Conditions(b *testing.B) {
+	matcher, _ := New("abc", "cba", "", "notpresentstring", "", "")
+	metric70 := []byte("abcde_fghij.klmnopqrst.uv_wxyz.1234567890abcdefg 12345.6789 1234567890") // key = 48, val = 10, ts = 10 -> 70
+	for i := 0; i < b.N; i++ {
+		matcher.Match(metric70)
+	}
+}
+
+func BenchmarkMatch4Conditions(b *testing.B) {
+	matcher, _ := New("abc", "cba", "klmno", "notpresentstring", "", "")
+	metric70 := []byte("abcde_fghij.klmnopqrst.uv_wxyz.1234567890abcdefg 12345.6789 1234567890") // key = 48, val = 10, ts = 10 -> 70
+	for i := 0; i < b.N; i++ {
+		matcher.Match(metric70)
+	}
+}

--- a/matcher/matcher_test.go
+++ b/matcher/matcher_test.go
@@ -4,6 +4,389 @@ import (
 	"testing"
 )
 
+type tcMatcher struct {
+	name               string
+	prefix             string
+	notPrefix          string
+	substr             string
+	notSubstr          string
+	regex              string
+	notRegex           string
+	expectInitError    bool
+	valuesIn           []string
+	matches            []bool
+	matchesExceptRegex []bool
+}
+
+func (tc tcMatcher) Run(t *testing.T) {
+	matcher, err := New(tc.prefix, tc.notPrefix, tc.substr, tc.notSubstr, tc.regex, tc.notRegex)
+	if err != nil && !tc.expectInitError {
+		t.Fatalf("%s: Unexepcted initialization error: %s", tc.name, err)
+	}
+	if err == nil && tc.expectInitError {
+		t.Fatalf("%s: Expected initialization error but didn't get one", tc.name)
+	}
+
+	for idx, value := range tc.valuesIn {
+		gotMatch := matcher.Match([]byte(value))
+		expectMatch := tc.matches[idx]
+		if gotMatch != expectMatch {
+			t.Fatalf("%s: Expected match to be %t but got %t: %s", tc.name, expectMatch, gotMatch, value)
+		}
+		gotMatchExceptRegex := matcher.MatchAllExceptRegex([]byte(value))
+		expectMatchExceptRegex := tc.matchesExceptRegex[idx]
+		if gotMatchExceptRegex != expectMatchExceptRegex {
+			t.Fatalf("%s: Expected matchExceptRegex to be %t but got %t: %s", tc.name, expectMatchExceptRegex, gotMatchExceptRegex, value)
+		}
+	}
+}
+
+func TestInvalidRegex(t *testing.T) {
+	tcMatcher{
+		name:            "test passing invalid regex",
+		regex:           "(abc",
+		expectInitError: true,
+	}.Run(t)
+}
+
+func TestInvalidNotRegex(t *testing.T) {
+	tcMatcher{
+		name:            "test passing invalid expression to notRegex",
+		notRegex:        "aaa)",
+		expectInitError: true,
+	}.Run(t)
+}
+
+func TestMatchingPrefix(t *testing.T) {
+	tcMatcher{
+		name:   "test prefix",
+		prefix: "aaa",
+		valuesIn: []string{
+			"abc",
+			"aaaaa",
+			"baab",
+			"a",
+		},
+		matches: []bool{
+			false,
+			true,
+			false,
+			false,
+		},
+		matchesExceptRegex: []bool{
+			false,
+			true,
+			false,
+			false,
+		},
+	}.Run(t)
+}
+
+func TestMatchingNotPrefix(t *testing.T) {
+	tcMatcher{
+		name:      "test notPrefix",
+		notPrefix: "aaa",
+		valuesIn: []string{
+			"abc",
+			"aaaaa",
+			"baab",
+			"a",
+		},
+		matches: []bool{
+			true,
+			false,
+			true,
+			true,
+		},
+		matchesExceptRegex: []bool{
+			true,
+			false,
+			true,
+			true,
+		},
+	}.Run(t)
+}
+
+func TestMatchingSubstr(t *testing.T) {
+	tcMatcher{
+		name:   "test substr",
+		substr: "aaa",
+		valuesIn: []string{
+			"abc",
+			"aaaaa",
+			"baaa",
+			"aaab",
+			"bbbaaabbb",
+			"aa",
+		},
+		matches: []bool{
+			false,
+			true,
+			true,
+			true,
+			true,
+			false,
+		},
+		matchesExceptRegex: []bool{
+			false,
+			true,
+			true,
+			true,
+			true,
+			false,
+		},
+	}.Run(t)
+}
+
+func TestMatchingNotSubstr(t *testing.T) {
+	tcMatcher{
+		name:      "test not substr",
+		notSubstr: "aaa",
+		valuesIn: []string{
+			"abc",
+			"aaaaa",
+			"baaa",
+			"aaab",
+			"bbbaaabbb",
+			"aa",
+		},
+		matches: []bool{
+			true,
+			false,
+			false,
+			false,
+			false,
+			true,
+		},
+		matchesExceptRegex: []bool{
+			true,
+			false,
+			false,
+			false,
+			false,
+			true,
+		},
+	}.Run(t)
+}
+
+func TestMatchingRegexAnchored(t *testing.T) {
+	tcMatcher{
+		name:  "test regex anchored",
+		regex: "^[a-c]{3}",
+		valuesIn: []string{
+			"abcdef",
+			"aad",
+			"daaab",
+		},
+		matches: []bool{
+			true,
+			false,
+			false,
+		},
+		matchesExceptRegex: []bool{
+			true,
+			true,
+			true,
+		},
+	}.Run(t)
+}
+
+func TestMatchingRegexNotAnchored(t *testing.T) {
+	tcMatcher{
+		name:  "test regex not anchored",
+		regex: "[a-c]{3}",
+		valuesIn: []string{
+			"abcdef",
+			"aadbbb",
+			"daaab",
+			"dadada",
+		},
+		matches: []bool{
+			true,
+			true,
+			true,
+			false,
+		},
+		matchesExceptRegex: []bool{
+			true,
+			true,
+			true,
+			true,
+		},
+	}.Run(t)
+}
+
+func TestMatchingNotRegexAnchored(t *testing.T) {
+	tcMatcher{
+		name:     "test not regex anchored",
+		notRegex: "^[a-c]{3}",
+		valuesIn: []string{
+			"abcdef",
+			"aad",
+			"daaab",
+		},
+		matches: []bool{
+			false,
+			true,
+			true,
+		},
+		matchesExceptRegex: []bool{
+			false,
+			true,
+			true,
+		},
+	}.Run(t)
+}
+
+func TestMatchingNotRegexNotAnchored(t *testing.T) {
+	tcMatcher{
+		name:     "test not regex not anchored",
+		notRegex: "[a-c]{3}",
+		valuesIn: []string{
+			"abcdef",
+			"aadbbb",
+			"daaab",
+			"dadada",
+		},
+		matches: []bool{
+			false,
+			false,
+			false,
+			true,
+		},
+		matchesExceptRegex: []bool{
+			false,
+			false,
+			false,
+			true,
+		},
+	}.Run(t)
+}
+
+func TestMatchingWith2Conditions(t *testing.T) {
+	tcMatcher{
+		name:   "test regex and prefix combined",
+		regex:  "[a-c]{3}",
+		prefix: "f",
+		valuesIn: []string{
+			"abcf",
+			"fabc",
+			"fffabc",
+			"fffab",
+			"abcffff",
+		},
+		matches: []bool{
+			false,
+			true,
+			true,
+			false,
+			false,
+		},
+		matchesExceptRegex: []bool{
+			false,
+			true,
+			true,
+			true,
+			false,
+		},
+	}.Run(t)
+}
+
+func TestMatchingWith3Conditions(t *testing.T) {
+	tcMatcher{
+		name:      "test regex, prefix and notPrefix combined",
+		regex:     "[a-c]{3}",
+		prefix:    "f",
+		notPrefix: "fa",
+		valuesIn: []string{
+			"fabc",
+			"fbca",
+			"fcba",
+			"fcb",
+			"cbaf",
+		},
+		matches: []bool{
+			false,
+			true,
+			true,
+			false,
+			false,
+		},
+		matchesExceptRegex: []bool{
+			false,
+			true,
+			true,
+			true,
+			false,
+		},
+	}.Run(t)
+
+	tcMatcher{
+		name:      "test sub, notSub and notRegex combined",
+		substr:    "a",
+		notSubstr: "aa",
+		notRegex:  "ab",
+		valuesIn: []string{
+			"aaa",
+			"aba",
+			"aab",
+			"aca",
+			"bab",
+			"bbb",
+			"cba",
+		},
+		matches: []bool{
+			false,
+			false,
+			false,
+			true,
+			false,
+			false,
+			true,
+		},
+		matchesExceptRegex: []bool{
+			false,
+			false,
+			false,
+			true,
+			false,
+			false,
+			true,
+		},
+	}.Run(t)
+}
+
+func TestMatchingWith4Conditions(t *testing.T) {
+	tcMatcher{
+		name:      "test regex, prefix, notSub and notPrefix combined",
+		regex:     "[a-c]{3}",
+		prefix:    "f",
+		notSubstr: "bca",
+		notPrefix: "fa",
+		valuesIn: []string{
+			"fabc",
+			"fbca",
+			"fcba",
+			"fcb",
+			"cbaf",
+		},
+		matches: []bool{
+			false,
+			false,
+			true,
+			false,
+			false,
+		},
+		matchesExceptRegex: []bool{
+			false,
+			false,
+			true,
+			true,
+			false,
+		},
+	}.Run(t)
+}
+
 func BenchmarkMatchPrefix(b *testing.B) {
 	matcher, _ := New("abcde_fghij.klmnopqrst", "", "", "", "", "")
 	metric70 := []byte("abcde_fghij.klmnopqrst.uv_wxyz.1234567890abcdefg 12345.6789 1234567890") // key = 48, val = 10, ts = 10 -> 70

--- a/matcher/matcher_test.go
+++ b/matcher/matcher_test.go
@@ -191,6 +191,28 @@ func TestMatchingRegexAnchored(t *testing.T) {
 	}.Run(t)
 }
 
+func TestMatchingRegexWithFixPrefix(t *testing.T) {
+	tcMatcher{
+		name:  "test regex anchored",
+		regex: "^abc.+",
+		valuesIn: []string{
+			"daaab",
+			"abc",
+			"abcdef",
+		},
+		matches: []bool{
+			false,
+			false,
+			true,
+		},
+		matchesExceptRegex: []bool{
+			false,
+			true,
+			true,
+		},
+	}.Run(t)
+}
+
 func TestMatchingRegexNotAnchored(t *testing.T) {
 	tcMatcher{
 		name:  "test regex not anchored",
@@ -231,7 +253,29 @@ func TestMatchingNotRegexAnchored(t *testing.T) {
 			true,
 		},
 		matchesExceptRegex: []bool{
+			true,
+			true,
+			true,
+		},
+	}.Run(t)
+}
+
+func TestMatchingNotRegexWithFixPrefix(t *testing.T) {
+	tcMatcher{
+		name:     "test not regex with fix prefix",
+		notRegex: "^abc.+",
+		valuesIn: []string{
+			"daab",
+			"abc",
+			"abcabc",
+		},
+		matches: []bool{
+			true,
+			true,
 			false,
+		},
+		matchesExceptRegex: []bool{
+			true,
 			true,
 			true,
 		},
@@ -255,9 +299,9 @@ func TestMatchingNotRegexNotAnchored(t *testing.T) {
 			true,
 		},
 		matchesExceptRegex: []bool{
-			false,
-			false,
-			false,
+			true,
+			true,
+			true,
 			true,
 		},
 	}.Run(t)
@@ -346,10 +390,10 @@ func TestMatchingWith3Conditions(t *testing.T) {
 		},
 		matchesExceptRegex: []bool{
 			false,
-			false,
-			false,
 			true,
 			false,
+			true,
+			true,
 			false,
 			true,
 		},

--- a/matcher/matcher_test.go
+++ b/matcher/matcher_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func BenchmarkMatchPrefix(b *testing.B) {
-	matcher, _ := New("abcde_fghij.klmnopqrst", "", "")
+	matcher, _ := New("abcde_fghij.klmnopqrst", "", "", "", "", "")
 	metric70 := []byte("abcde_fghij.klmnopqrst.uv_wxyz.1234567890abcdefg 12345.6789 1234567890") // key = 48, val = 10, ts = 10 -> 70
 	for i := 0; i < b.N; i++ {
 		matcher.Match(metric70)
@@ -13,7 +13,7 @@ func BenchmarkMatchPrefix(b *testing.B) {
 }
 
 func BenchmarkMatchSubstr(b *testing.B) {
-	matcher, _ := New("", "1234567890abc", "")
+	matcher, _ := New("", "", "1234567890abc", "", "", "")
 	metric70 := []byte("abcde_fghij.klmnopqrst.uv_wxyz.1234567890abcdefg 12345.6789 1234567890") // key = 48, val = 10, ts = 10 -> 70
 	for i := 0; i < b.N; i++ {
 		matcher.Match(metric70)
@@ -21,7 +21,7 @@ func BenchmarkMatchSubstr(b *testing.B) {
 }
 
 func BenchmarkMatchRegex(b *testing.B) {
-	matcher, _ := New("", "", "abcde_(fghij|foo).[^\\.]+.\\.*.\\.*")
+	matcher, _ := New("", "", "", "", "abcde_(fghij|foo).[^\\.]+.\\.*.\\.*", "")
 	metric70 := []byte("abcde_fghij.klmnopqrst.uv_wxyz.1234567890abcdefg 12345.6789 1234567890") // key = 48, val = 10, ts = 10 -> 70
 	for i := 0; i < b.N; i++ {
 		matcher.Match(metric70)

--- a/matcher/matcher_test.go
+++ b/matcher/matcher_test.go
@@ -33,7 +33,7 @@ func (tc tcMatcher) Run(t *testing.T) {
 		if gotMatch != expectMatch {
 			t.Fatalf("%s: Expected match to be %t but got %t: %s", tc.name, expectMatch, gotMatch, value)
 		}
-		gotMatchExceptRegex := matcher.MatchAllExceptRegex([]byte(value))
+		gotMatchExceptRegex := matcher.PreMatch([]byte(value))
 		expectMatchExceptRegex := tc.matchesExceptRegex[idx]
 		if gotMatchExceptRegex != expectMatchExceptRegex {
 			t.Fatalf("%s: Expected matchExceptRegex to be %t but got %t: %s", tc.name, expectMatchExceptRegex, gotMatchExceptRegex, value)

--- a/route/cloudwatch.go
+++ b/route/cloudwatch.go
@@ -5,17 +5,17 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Dieterbe/go-metrics"
-	dest "github.com/grafana/carbon-relay-ng/destination"
-	"github.com/grafana/carbon-relay-ng/matcher"
+	"strconv"
+	"strings"
 
+	"github.com/Dieterbe/go-metrics"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	dest "github.com/grafana/carbon-relay-ng/destination"
+	"github.com/grafana/carbon-relay-ng/matcher"
 	"github.com/grafana/carbon-relay-ng/stats"
 	log "github.com/sirupsen/logrus"
-	"strconv"
-	"strings"
 )
 
 // Publishes data points to the native AWS metrics service: CloudWatch
@@ -51,8 +51,8 @@ type CloudWatch struct {
 
 // NewCloudWatch creates a route that writes metrics to the AWS service CloudWatch
 // We will automatically run the route and the destination
-func NewCloudWatch(key, prefix, sub, regex, awsProfile, awsRegion, awsNamespace string, awsDimensions [][]string, bufSize, flushMaxSize, flushMaxWait int, storageResolution int64, blocking bool) (Route, error) {
-	m, err := matcher.New(prefix, sub, regex)
+func NewCloudWatch(key, prefix, notPrefix, sub, notSub, regex, notRegex, awsProfile, awsRegion, awsNamespace string, awsDimensions [][]string, bufSize, flushMaxSize, flushMaxWait int, storageResolution int64, blocking bool) (Route, error) {
+	m, err := matcher.New(prefix, notPrefix, sub, notSub, regex, notRegex)
 	if err != nil {
 		return nil, err
 	}

--- a/route/cloudwatch.go
+++ b/route/cloudwatch.go
@@ -51,11 +51,7 @@ type CloudWatch struct {
 
 // NewCloudWatch creates a route that writes metrics to the AWS service CloudWatch
 // We will automatically run the route and the destination
-func NewCloudWatch(key, prefix, notPrefix, sub, notSub, regex, notRegex, awsProfile, awsRegion, awsNamespace string, awsDimensions [][]string, bufSize, flushMaxSize, flushMaxWait int, storageResolution int64, blocking bool) (Route, error) {
-	m, err := matcher.New(prefix, notPrefix, sub, notSub, regex, notRegex)
-	if err != nil {
-		return nil, err
-	}
+func NewCloudWatch(key string, matcher matcher.Matcher, awsProfile, awsRegion, awsNamespace string, awsDimensions [][]string, bufSize, flushMaxSize, flushMaxWait int, storageResolution int64, blocking bool) (Route, error) {
 
 	r := &CloudWatch{
 		awsProfile:         awsProfile,
@@ -114,7 +110,7 @@ func NewCloudWatch(key, prefix, notPrefix, sub, notSub, regex, notRegex, awsProf
 	// Create new CloudWatch client.
 	r.client = cloudwatch.New(r.session)
 
-	r.config.Store(baseConfig{*m, make([]*dest.Destination, 0)})
+	r.config.Store(baseConfig{matcher, make([]*dest.Destination, 0)})
 	go r.run()
 	return r, nil
 }

--- a/route/grafananet.go
+++ b/route/grafananet.go
@@ -62,11 +62,7 @@ type GrafanaNet struct {
 // NewGrafanaNet creates a special route that writes to a grafana.net datastore
 // We will automatically run the route and the destination
 // ignores spool for now
-func NewGrafanaNet(key, prefix, notPrefix, sub, notSub, regex, notRegex, addr, apiKey, schemasFile string, spool, sslVerify, blocking bool, bufSize, flushMaxNum, flushMaxWait, timeout, concurrency, orgId int) (Route, error) {
-	m, err := matcher.New(prefix, notPrefix, sub, notSub, regex, notRegex)
-	if err != nil {
-		return nil, err
-	}
+func NewGrafanaNet(key string, matcher matcher.Matcher, addr, apiKey, schemasFile string, spool, sslVerify, blocking bool, bufSize, flushMaxNum, flushMaxWait, timeout, concurrency, orgId int) (Route, error) {
 	schemas, err := getSchemas(schemasFile)
 	if err != nil {
 		return nil, err
@@ -116,7 +112,7 @@ func NewGrafanaNet(key, prefix, notPrefix, sub, notSub, regex, notRegex, addr, a
 		r.in[i] = make(chan []byte, bufSize/r.concurrency)
 		go r.run(r.in[i])
 	}
-	r.config.Store(baseConfig{*m, make([]*dest.Destination, 0)})
+	r.config.Store(baseConfig{matcher, make([]*dest.Destination, 0)})
 
 	// start off with a transport the same as Go's DefaultTransport
 	transport := &http.Transport{

--- a/route/grafananet.go
+++ b/route/grafananet.go
@@ -62,8 +62,8 @@ type GrafanaNet struct {
 // NewGrafanaNet creates a special route that writes to a grafana.net datastore
 // We will automatically run the route and the destination
 // ignores spool for now
-func NewGrafanaNet(key, prefix, sub, regex, addr, apiKey, schemasFile string, spool, sslVerify, blocking bool, bufSize, flushMaxNum, flushMaxWait, timeout, concurrency, orgId int) (Route, error) {
-	m, err := matcher.New(prefix, sub, regex)
+func NewGrafanaNet(key, prefix, notPrefix, sub, notSub, regex, notRegex, addr, apiKey, schemasFile string, spool, sslVerify, blocking bool, bufSize, flushMaxNum, flushMaxWait, timeout, concurrency, orgId int) (Route, error) {
+	m, err := matcher.New(prefix, notPrefix, sub, notSub, regex, notRegex)
 	if err != nil {
 		return nil, err
 	}

--- a/route/kafkamdm.go
+++ b/route/kafkamdm.go
@@ -51,8 +51,8 @@ type KafkaMdm struct {
 
 // NewKafkaMdm creates a special route that writes to a grafana.net datastore
 // We will automatically run the route and the destination
-func NewKafkaMdm(key, prefix, sub, regex, topic, codec, schemasFile, partitionBy string, brokers []string, bufSize, orgId, flushMaxNum, flushMaxWait, timeout int, blocking bool) (Route, error) {
-	m, err := matcher.New(prefix, sub, regex)
+func NewKafkaMdm(key, prefix, notPrefix, sub, notSub, regex, notRegex, topic, codec, schemasFile, partitionBy string, brokers []string, bufSize, orgId, flushMaxNum, flushMaxWait, timeout int, blocking bool) (Route, error) {
+	m, err := matcher.New(prefix, notPrefix, sub, notSub, regex, notRegex)
 	if err != nil {
 		return nil, err
 	}

--- a/route/kafkamdm.go
+++ b/route/kafkamdm.go
@@ -51,11 +51,7 @@ type KafkaMdm struct {
 
 // NewKafkaMdm creates a special route that writes to a grafana.net datastore
 // We will automatically run the route and the destination
-func NewKafkaMdm(key, prefix, notPrefix, sub, notSub, regex, notRegex, topic, codec, schemasFile, partitionBy string, brokers []string, bufSize, orgId, flushMaxNum, flushMaxWait, timeout int, blocking bool) (Route, error) {
-	m, err := matcher.New(prefix, notPrefix, sub, notSub, regex, notRegex)
-	if err != nil {
-		return nil, err
-	}
+func NewKafkaMdm(key string, matcher matcher.Matcher, topic, codec, schemasFile, partitionBy string, brokers []string, bufSize, orgId, flushMaxNum, flushMaxWait, timeout int, blocking bool) (Route, error) {
 	schemas, err := getSchemas(schemasFile)
 	if err != nil {
 		return nil, err
@@ -118,7 +114,7 @@ func NewKafkaMdm(key, prefix, notPrefix, sub, notSub, regex, notRegex, topic, co
 	}
 	r.saramaCfg = config
 
-	r.config.Store(baseConfig{*m, make([]*dest.Destination, 0)})
+	r.config.Store(baseConfig{matcher, make([]*dest.Destination, 0)})
 	go r.run()
 	return r, nil
 }

--- a/route/pubsub.go
+++ b/route/pubsub.go
@@ -62,12 +62,7 @@ type PubSub struct {
 
 // NewPubSub creates a route that writes metrics to a Google PubSub topic
 // We will automatically run the route and the destination
-func NewPubSub(key, prefix, notPrefix, sub, notSub, regex, notRegex, project, topic, format, codec string, bufSize, flushMaxSize, flushMaxWait int, blocking bool) (Route, error) {
-	m, err := matcher.New(prefix, notPrefix, sub, notSub, regex, notRegex)
-	if err != nil {
-		return nil, err
-	}
-
+func NewPubSub(key string, matcher matcher.Matcher, project, topic, format, codec string, bufSize, flushMaxSize, flushMaxWait int, blocking bool) (Route, error) {
 	r := &PubSub{
 		baseRoute: baseRoute{sync.Mutex{}, atomic.Value{}, key},
 		project:   project,
@@ -117,7 +112,7 @@ func NewPubSub(key, prefix, notPrefix, sub, notSub, regex, notRegex, project, to
 	}
 	r.psTopic = psTopic
 
-	r.config.Store(baseConfig{*m, make([]*dest.Destination, 0)})
+	r.config.Store(baseConfig{matcher, make([]*dest.Destination, 0)})
 	go r.run()
 	return r, nil
 }

--- a/route/pubsub.go
+++ b/route/pubsub.go
@@ -62,8 +62,8 @@ type PubSub struct {
 
 // NewPubSub creates a route that writes metrics to a Google PubSub topic
 // We will automatically run the route and the destination
-func NewPubSub(key, prefix, sub, regex, project, topic, format, codec string, bufSize, flushMaxSize, flushMaxWait int, blocking bool) (Route, error) {
-	m, err := matcher.New(prefix, sub, regex)
+func NewPubSub(key, prefix, notPrefix, sub, notSub, regex, notRegex, project, topic, format, codec string, bufSize, flushMaxSize, flushMaxWait int, blocking bool) (Route, error) {
+	m, err := matcher.New(prefix, notPrefix, sub, notSub, regex, notRegex)
 	if err != nil {
 		return nil, err
 	}

--- a/route/route.go
+++ b/route/route.go
@@ -76,38 +76,26 @@ type ConsistentHashing struct {
 
 // NewSendAllMatch creates a sendAllMatch route.
 // We will automatically run the route and the given destinations
-func NewSendAllMatch(key, prefix, notPrefix, sub, notSub, regex, notRegex string, destinations []*dest.Destination) (Route, error) {
-	m, err := matcher.New(prefix, notPrefix, sub, notSub, regex, notRegex)
-	if err != nil {
-		return nil, err
-	}
+func NewSendAllMatch(key string, matcher matcher.Matcher, destinations []*dest.Destination) (Route, error) {
 	r := &SendAllMatch{baseRoute{sync.Mutex{}, atomic.Value{}, key}}
-	r.config.Store(baseConfig{*m, destinations})
+	r.config.Store(baseConfig{matcher, destinations})
 	r.run()
 	return r, nil
 }
 
 // NewSendFirstMatch creates a sendFirstMatch route.
 // We will automatically run the route and the given destinations
-func NewSendFirstMatch(key, prefix, notPrefix, sub, notSub, regex, notRegex string, destinations []*dest.Destination) (Route, error) {
-	m, err := matcher.New(prefix, notPrefix, sub, notSub, regex, notRegex)
-	if err != nil {
-		return nil, err
-	}
+func NewSendFirstMatch(key string, matcher matcher.Matcher, destinations []*dest.Destination) (Route, error) {
 	r := &SendFirstMatch{baseRoute{sync.Mutex{}, atomic.Value{}, key}}
-	r.config.Store(baseConfig{*m, destinations})
+	r.config.Store(baseConfig{matcher, destinations})
 	r.run()
 	return r, nil
 }
 
-func NewConsistentHashing(key, prefix, notPrefix, sub, notSub, regex, notRegex string, destinations []*dest.Destination) (Route, error) {
-	m, err := matcher.New(prefix, notPrefix, sub, notSub, regex, notRegex)
-	if err != nil {
-		return nil, err
-	}
+func NewConsistentHashing(key string, matcher matcher.Matcher, destinations []*dest.Destination) (Route, error) {
 	r := &ConsistentHashing{baseRoute{sync.Mutex{}, atomic.Value{}, key}}
 	hasher := NewConsistentHasher(destinations)
-	r.config.Store(consistentHashingConfig{baseConfig{*m, destinations},
+	r.config.Store(consistentHashingConfig{baseConfig{matcher, destinations},
 		&hasher})
 	r.run()
 	return r, nil
@@ -350,7 +338,7 @@ func (route *baseRoute) update(opts map[string]string, extendConfig baseCfgExten
 		if err != nil {
 			return err
 		}
-		conf = extendConfig(baseConfig{*match, conf.Dests()})
+		conf = extendConfig(baseConfig{match, conf.Dests()})
 	}
 	route.config.Store(conf)
 	return nil

--- a/route/route.go
+++ b/route/route.go
@@ -76,8 +76,8 @@ type ConsistentHashing struct {
 
 // NewSendAllMatch creates a sendAllMatch route.
 // We will automatically run the route and the given destinations
-func NewSendAllMatch(key, prefix, sub, regex string, destinations []*dest.Destination) (Route, error) {
-	m, err := matcher.New(prefix, sub, regex)
+func NewSendAllMatch(key, prefix, notPrefix, sub, notSub, regex, notRegex string, destinations []*dest.Destination) (Route, error) {
+	m, err := matcher.New(prefix, notPrefix, sub, notSub, regex, notRegex)
 	if err != nil {
 		return nil, err
 	}
@@ -89,8 +89,8 @@ func NewSendAllMatch(key, prefix, sub, regex string, destinations []*dest.Destin
 
 // NewSendFirstMatch creates a sendFirstMatch route.
 // We will automatically run the route and the given destinations
-func NewSendFirstMatch(key, prefix, sub, regex string, destinations []*dest.Destination) (Route, error) {
-	m, err := matcher.New(prefix, sub, regex)
+func NewSendFirstMatch(key, prefix, notPrefix, sub, notSub, regex, notRegex string, destinations []*dest.Destination) (Route, error) {
+	m, err := matcher.New(prefix, notPrefix, sub, notSub, regex, notRegex)
 	if err != nil {
 		return nil, err
 	}
@@ -100,8 +100,8 @@ func NewSendFirstMatch(key, prefix, sub, regex string, destinations []*dest.Dest
 	return r, nil
 }
 
-func NewConsistentHashing(key, prefix, sub, regex string, destinations []*dest.Destination) (Route, error) {
-	m, err := matcher.New(prefix, sub, regex)
+func NewConsistentHashing(key, prefix, notPrefix, sub, notSub, regex, notRegex string, destinations []*dest.Destination) (Route, error) {
+	m, err := matcher.New(prefix, notPrefix, sub, notSub, regex, notRegex)
 	if err != nil {
 		return nil, err
 	}
@@ -314,8 +314,11 @@ func (route *baseRoute) update(opts map[string]string, extendConfig baseCfgExten
 	conf := route.config.Load().(Config)
 	match := conf.Matcher()
 	prefix := match.Prefix
+	notPrefix := match.NotPrefix
 	sub := match.Sub
+	notSub := match.NotSub
 	regex := match.Regex
+	notRegex := match.NotRegex
 	updateMatcher := false
 
 	for name, val := range opts {
@@ -323,18 +326,27 @@ func (route *baseRoute) update(opts map[string]string, extendConfig baseCfgExten
 		case "prefix":
 			prefix = val
 			updateMatcher = true
+		case "notPrefix":
+			notPrefix = val
+			updateMatcher = true
 		case "sub":
 			sub = val
 			updateMatcher = true
+		case "notSub":
+			notSub = val
+			updateMatcher = true
 		case "regex":
 			regex = val
+			updateMatcher = true
+		case "notRegex":
+			notRegex = val
 			updateMatcher = true
 		default:
 			return fmt.Errorf("no such option '%s'", name)
 		}
 	}
 	if updateMatcher {
-		match, err := matcher.New(prefix, sub, regex)
+		match, err := matcher.New(prefix, notPrefix, sub, notSub, regex, notRegex)
 		if err != nil {
 			return err
 		}

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 
 	"github.com/grafana/carbon-relay-ng/destination"
+	"github.com/grafana/carbon-relay-ng/matcher"
 )
 
 // just sending into route, no matching or sending to dest
 func BenchmarkRouteDispatchMetric(b *testing.B) {
-	route, err := NewSendAllMatch("", "", "", "", "", "", "", make([]*destination.Destination, 0))
+	route, err := NewSendAllMatch("", matcher.Matcher{}, make([]*destination.Destination, 0))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -8,7 +8,7 @@ import (
 
 // just sending into route, no matching or sending to dest
 func BenchmarkRouteDispatchMetric(b *testing.B) {
-	route, err := NewSendAllMatch("", "", "", "", make([]*destination.Destination, 0))
+	route, err := NewSendAllMatch("", "", "", "", "", "", "", make([]*destination.Destination, 0))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/table/table.go
+++ b/table/table.go
@@ -401,24 +401,36 @@ func (table *Table) Print() (str string) {
 	// the default values can be arbitrary (bot not smaller than the column titles),
 	// 'R' stands for Route, 'D' for dest, 'B' blacklist, 'A" for aggregation, 'RW' for rewriter
 	maxBPrefix := 6
+	maxBNotPrefix := 9
 	maxBSub := 6
+	maxBNotSub := 9
 	maxBRegex := 5
+	maxBNotRegex := 8
 	maxAKey := 4
 	maxAFunc := 4
 	maxARegex := 5
+	maxANotRegex := 8
 	maxAPrefix := 6
+	maxANotPrefix := 9
 	maxASub := 6
+	maxANotSub := 9
 	maxAOutFmt := 6
 	maxAInterval := 8
 	maxAwait := 4
 	maxRType := 4
 	maxRKey := 3
 	maxRPrefix := 6
+	maxRNotPrefix := 9
 	maxRSub := 6
+	maxRNotSub := 9
 	maxRRegex := 5
+	maxRNotRegex := 8
 	maxDPrefix := 6
+	maxDNotPrefix := 9
 	maxDSub := 6
+	maxDNotSub := 9
 	maxDRegex := 5
+	maxDNotRegex := 8
 	maxDAddr := 16
 	maxDSpoolDir := 16
 
@@ -436,15 +448,21 @@ func (table *Table) Print() (str string) {
 	}
 	for _, black := range t.Blacklist {
 		maxBPrefix = max(maxBPrefix, len(black.Prefix))
+		maxBNotPrefix = max(maxBNotPrefix, len(black.NotPrefix))
 		maxBSub = max(maxBSub, len(black.Sub))
+		maxBNotSub = max(maxBNotSub, len(black.NotSub))
 		maxBRegex = max(maxBRegex, len(black.Regex))
+		maxBNotRegex = max(maxBNotRegex, len(black.NotRegex))
 	}
 	for _, agg := range t.Aggregators {
 		maxAKey = max(maxAKey, len(agg.Key))
 		maxAFunc = max(maxAFunc, len(agg.Fun))
 		maxARegex = max(maxARegex, len(agg.Matcher.Regex))
+		maxANotRegex = max(maxANotRegex, len(agg.Matcher.NotRegex))
 		maxAPrefix = max(maxAPrefix, len(agg.Matcher.Prefix))
+		maxANotPrefix = max(maxANotPrefix, len(agg.Matcher.NotPrefix))
 		maxASub = max(maxASub, len(agg.Matcher.Sub))
+		maxANotSub = max(maxANotSub, len(agg.Matcher.NotSub))
 		maxAOutFmt = max(maxAOutFmt, len(agg.OutFmt))
 		maxAInterval = max(maxAInterval, len(fmt.Sprintf("%d", agg.Interval)))
 		maxAwait = max(maxAwait, len(fmt.Sprintf("%d", agg.Wait)))
@@ -453,26 +471,32 @@ func (table *Table) Print() (str string) {
 		maxRType = max(maxRType, len(route.Type))
 		maxRKey = max(maxRKey, len(route.Key))
 		maxRPrefix = max(maxRPrefix, len(route.Matcher.Prefix))
+		maxRNotPrefix = max(maxRNotPrefix, len(route.Matcher.NotPrefix))
 		maxRSub = max(maxRSub, len(route.Matcher.Sub))
+		maxRNotSub = max(maxRNotSub, len(route.Matcher.NotSub))
 		maxRRegex = max(maxRRegex, len(route.Matcher.Regex))
+		maxRNotRegex = max(maxRNotRegex, len(route.Matcher.NotRegex))
 		for _, dest := range route.Dests {
 			maxDPrefix = max(maxDPrefix, len(dest.Matcher.Prefix))
+			maxDNotPrefix = max(maxDNotPrefix, len(dest.Matcher.NotPrefix))
 			maxDSub = max(maxDSub, len(dest.Matcher.Sub))
+			maxDNotSub = max(maxDNotSub, len(dest.Matcher.NotSub))
 			maxDRegex = max(maxDRegex, len(dest.Matcher.Regex))
+			maxDNotRegex = max(maxDNotRegex, len(dest.Matcher.NotRegex))
 			maxDAddr = max(maxDAddr, len(dest.Addr))
 			maxDSpoolDir = max(maxDSpoolDir, len(dest.SpoolDir))
 		}
 	}
 	heaFmtRW := fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds  %%-%ds\n", maxRWOld, maxRWNew, maxRWNot, maxRWMax)
 	rowFmtRW := fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds  %%-%dd\n", maxRWOld, maxRWNew, maxRWNot, maxRWMax)
-	heaFmtB := fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds\n", maxBPrefix, maxBSub, maxBRegex)
-	rowFmtB := fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds\n", maxBPrefix, maxBSub, maxBRegex)
-	heaFmtA := fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-5s  %%-%ds  %%-%ds %%-7s\n", maxAKey, maxAFunc, maxARegex, maxAPrefix, maxASub, maxAOutFmt, maxAInterval, maxAwait)
-	rowFmtA := fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-5t  %%-%dd  %%-%dd %%-7t\n", maxAKey, maxAFunc, maxARegex, maxAPrefix, maxASub, maxAOutFmt, maxAInterval, maxAwait)
-	heaFmtR := fmt.Sprintf("  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds\n", maxRType, maxRKey, maxRPrefix, maxRSub, maxRRegex)
-	rowFmtR := fmt.Sprintf("> %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds\n", maxRType, maxRKey, maxRPrefix, maxRSub, maxRRegex)
-	heaFmtD := fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-5s  %%-6s  %%-6s\n", maxDPrefix, maxDSub, maxDRegex, maxDAddr, maxDSpoolDir)
-	rowFmtD := fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-5t  %%-6t  %%-6t\n", maxDPrefix, maxDSub, maxDRegex, maxDAddr, maxDSpoolDir)
+	heaFmtB := fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds\n", maxBPrefix, maxBNotPrefix, maxBSub, maxBNotSub, maxBRegex, maxBNotRegex)
+	rowFmtB := fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds\n", maxBPrefix, maxBNotPrefix, maxBSub, maxBNotSub, maxBRegex, maxBNotRegex)
+	heaFmtA := fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-5s  %%-%ds  %%-%ds %%-7s\n", maxAKey, maxAFunc, maxARegex, maxANotRegex, maxAPrefix, maxANotPrefix, maxASub, maxANotSub, maxAOutFmt, maxAInterval, maxAwait)
+	rowFmtA := fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-5t  %%-%dd  %%-%dd %%-7t\n", maxAKey, maxAFunc, maxARegex, maxANotRegex, maxAPrefix, maxANotPrefix, maxASub, maxANotSub, maxAOutFmt, maxAInterval, maxAwait)
+	heaFmtR := fmt.Sprintf("  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds\n", maxRType, maxRKey, maxRPrefix, maxRNotPrefix, maxRSub, maxRNotSub, maxRRegex, maxRNotRegex)
+	rowFmtR := fmt.Sprintf("> %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds\n", maxRType, maxRKey, maxRPrefix, maxRNotPrefix, maxRSub, maxRNotSub, maxRRegex, maxRNotRegex)
+	heaFmtD := fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-5s  %%-6s  %%-6s\n", maxDPrefix, maxDNotPrefix, maxDSub, maxDNotSub, maxDRegex, maxDNotRegex, maxDAddr, maxDSpoolDir)
+	rowFmtD := fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-5t  %%-6t  %%-6t\n", maxDPrefix, maxDNotPrefix, maxDSub, maxDNotSub, maxDRegex, maxDNotRegex, maxDAddr, maxDSpoolDir)
 
 	underscore := func(amount int) string {
 		return strings.Repeat("=", amount) + "\n"
@@ -486,29 +510,29 @@ func (table *Table) Print() (str string) {
 	}
 
 	str += "\n## Blacklist:\n"
-	cols = fmt.Sprintf(heaFmtB, "prefix", "substr", "regex")
+	cols = fmt.Sprintf(heaFmtB, "prefix", "notPrefix", "substr", "notSubstr", "regex", "notRegex")
 	str += cols + underscore(len(cols)-1)
 	for _, black := range t.Blacklist {
-		str += fmt.Sprintf(rowFmtB, black.Prefix, black.Sub, black.Regex)
+		str += fmt.Sprintf(rowFmtB, black.Prefix, black.NotPrefix, black.Sub, black.NotSub, black.Regex, black.NotRegex)
 	}
 
 	str += "\n## Aggregations:\n"
-	cols = fmt.Sprintf(heaFmtA, "key", "func", "regex", "prefix", "substr", "outFmt", "cache", "interval", "wait", "dropRaw")
+	cols = fmt.Sprintf(heaFmtA, "key", "func", "regex", "notRegex", "prefix", "notPrefix", "substr", "notSubstr", "outFmt", "cache", "interval", "wait", "dropRaw")
 	str += cols + underscore(len(cols)-1)
 	for _, agg := range t.Aggregators {
-		str += fmt.Sprintf(rowFmtA, agg.Key, agg.Fun, agg.Matcher.Regex, agg.Matcher.Prefix, agg.Matcher.Sub, agg.OutFmt, agg.Cache, agg.Interval, agg.Wait, agg.DropRaw)
+		str += fmt.Sprintf(rowFmtA, agg.Key, agg.Fun, agg.Matcher.Regex, agg.Matcher.NotRegex, agg.Matcher.Prefix, agg.Matcher.NotPrefix, agg.Matcher.Sub, agg.Matcher.NotSub, agg.OutFmt, agg.Cache, agg.Interval, agg.Wait, agg.DropRaw)
 	}
 
 	str += "\n## Routes:\n"
-	cols = fmt.Sprintf(heaFmtR, "type", "key", "prefix", "substr", "regex")
-	rcols := fmt.Sprintf(heaFmtD, "prefix", "substr", "regex", "addr", "spoolDir", "spool", "pickle", "online")
+	cols = fmt.Sprintf(heaFmtR, "type", "key", "prefix", "notPrefix", "substr", "notSubstr", "regex", "notRegex")
+	rcols := fmt.Sprintf(heaFmtD, "prefix", "notPrefix", "substr", "notSubstr", "regex", "notRegex", "addr", "spoolDir", "spool", "pickle", "online")
 	indent := "  "
 	str += cols + underscore(max(len(cols), len(rcols)+len(indent))-1)
 	divider := indent + strings.Repeat("-", max(len(cols)-len(indent), len(rcols))-1) + "\n"
 
 	for _, route := range t.Routes {
 		m := route.Matcher
-		str += fmt.Sprintf(rowFmtR, route.Type, route.Key, m.Prefix, m.Sub, m.Regex)
+		str += fmt.Sprintf(rowFmtR, route.Type, route.Key, m.Prefix, m.NotPrefix, m.Sub, m.NotSub, m.Regex, m.NotRegex)
 		if route.Type == "GrafanaNet" {
 			str += indent + route.Addr + "\n"
 			continue
@@ -520,7 +544,7 @@ func (table *Table) Print() (str string) {
 		str += indent + rcols + divider
 		for _, dest := range route.Dests {
 			m := dest.Matcher
-			str += indent + fmt.Sprintf(rowFmtD, m.Prefix, m.Sub, m.Regex, dest.Addr, dest.SpoolDir, dest.Spool, dest.Pickle, dest.Online)
+			str += indent + fmt.Sprintf(rowFmtD, m.Prefix, m.NotPrefix, m.Sub, m.NotSub, m.Regex, m.NotRegex, dest.Addr, dest.SpoolDir, dest.Spool, dest.Pickle, dest.Online)
 		}
 		str += "\n"
 	}

--- a/table/table.go
+++ b/table/table.go
@@ -595,21 +595,30 @@ func (table *Table) InitBlacklist(config cfg.Config) error {
 		}
 
 		prefix := ""
+		notPrefix := ""
 		sub := ""
+		notSub := ""
 		regex := ""
+		notRegex := ""
 
 		switch parts[0] {
 		case "prefix":
 			prefix = parts[1]
+		case "notPrefix":
+			notPrefix = parts[1]
 		case "sub":
 			sub = parts[1]
+		case "notSub":
+			notSub = parts[1]
 		case "regex":
 			regex = parts[1]
+		case "notRegex":
+			notRegex = parts[1]
 		default:
 			return fmt.Errorf("invalid blacklist method for cmd #%d: %s", i+1, parts[1])
 		}
 
-		m, err := matcher.New(prefix, sub, regex)
+		m, err := matcher.New(prefix, notPrefix, sub, notSub, regex, notRegex)
 		if err != nil {
 			log.Error(err.Error())
 			return fmt.Errorf("could not apply blacklist cmd #%d", i+1)
@@ -623,7 +632,7 @@ func (table *Table) InitBlacklist(config cfg.Config) error {
 
 func (table *Table) InitAggregation(config cfg.Config) error {
 	for i, aggConfig := range config.Aggregation {
-		agg, err := aggregator.New(aggConfig.Function, aggConfig.Regex, aggConfig.Prefix, aggConfig.Substr, aggConfig.Format, aggConfig.Cache, uint(aggConfig.Interval), uint(aggConfig.Wait), aggConfig.DropRaw, table.In)
+		agg, err := aggregator.New(aggConfig.Function, aggConfig.Regex, aggConfig.NotRegex, aggConfig.Prefix, aggConfig.NotPrefix, aggConfig.Substr, aggConfig.NotSubstr, aggConfig.Format, aggConfig.Cache, uint(aggConfig.Interval), uint(aggConfig.Wait), aggConfig.DropRaw, table.In)
 		if err != nil {
 			log.Error(err.Error())
 			return fmt.Errorf("could not add aggregation #%d", i+1)
@@ -662,7 +671,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				return fmt.Errorf("must get at least 1 destination for route '%s'", routeConfig.Key)
 			}
 
-			route, err := route.NewSendAllMatch(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, destinations)
+			route, err := route.NewSendAllMatch(routeConfig.Key, routeConfig.Prefix, routeConfig.NotPrefix, routeConfig.Substr, routeConfig.NotSubstr, routeConfig.Regex, routeConfig.NotRegex, destinations)
 			if err != nil {
 				log.Error(err.Error())
 				return fmt.Errorf("error adding route '%s'", routeConfig.Key)
@@ -678,7 +687,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				return fmt.Errorf("must get at least 1 destination for route '%s'", routeConfig.Key)
 			}
 
-			route, err := route.NewSendFirstMatch(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, destinations)
+			route, err := route.NewSendFirstMatch(routeConfig.Key, routeConfig.Prefix, routeConfig.NotPrefix, routeConfig.Substr, routeConfig.NotSubstr, routeConfig.Regex, routeConfig.NotRegex, destinations)
 			if err != nil {
 				log.Error(err.Error())
 				return fmt.Errorf("error adding route '%s'", routeConfig.Key)
@@ -694,7 +703,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				return fmt.Errorf("must get at least 2 destination for route '%s'", routeConfig.Key)
 			}
 
-			route, err := route.NewConsistentHashing(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, destinations)
+			route, err := route.NewConsistentHashing(routeConfig.Key, routeConfig.Prefix, routeConfig.NotPrefix, routeConfig.Substr, routeConfig.NotSubstr, routeConfig.Regex, routeConfig.NotRegex, destinations)
 			if err != nil {
 				log.Error(err.Error())
 				return fmt.Errorf("error adding route '%s'", routeConfig.Key)
@@ -756,7 +765,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				orgId = routeConfig.OrgId
 			}
 
-			route, err := route.NewGrafanaNet(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, routeConfig.Addr, routeConfig.ApiKey, routeConfig.SchemasFile, spool, sslVerify, routeConfig.Blocking, bufSize, flushMaxNum, flushMaxWait, timeout, concurrency, orgId)
+			route, err := route.NewGrafanaNet(routeConfig.Key, routeConfig.Prefix, routeConfig.NotPrefix, routeConfig.Substr, routeConfig.NotSubstr, routeConfig.Regex, routeConfig.NotRegex, routeConfig.Addr, routeConfig.ApiKey, routeConfig.SchemasFile, spool, sslVerify, routeConfig.Blocking, bufSize, flushMaxNum, flushMaxWait, timeout, concurrency, orgId)
 			if err != nil {
 				log.Error(err.Error())
 				return fmt.Errorf("error adding route '%s'", routeConfig.Key)
@@ -790,7 +799,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				orgId = routeConfig.OrgId
 			}
 
-			route, err := route.NewKafkaMdm(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, routeConfig.Topic, routeConfig.Codec, routeConfig.SchemasFile, routeConfig.PartitionBy, routeConfig.Brokers, bufSize, orgId, flushMaxNum, flushMaxWait, timeout, routeConfig.Blocking)
+			route, err := route.NewKafkaMdm(routeConfig.Key, routeConfig.Prefix, routeConfig.NotPrefix, routeConfig.Substr, routeConfig.NotSubstr, routeConfig.Regex, routeConfig.NotRegex, routeConfig.Topic, routeConfig.Codec, routeConfig.SchemasFile, routeConfig.PartitionBy, routeConfig.Brokers, bufSize, orgId, flushMaxNum, flushMaxWait, timeout, routeConfig.Blocking)
 			if err != nil {
 				log.Error(err.Error())
 				return fmt.Errorf("error adding route '%s'", routeConfig.Key)
@@ -819,7 +828,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				flushMaxWait = routeConfig.FlushMaxWait
 			}
 
-			route, err := route.NewPubSub(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, routeConfig.Project, routeConfig.Topic, format, codec, bufSize, flushMaxSize, flushMaxWait, routeConfig.Blocking)
+			route, err := route.NewPubSub(routeConfig.Key, routeConfig.Prefix, routeConfig.NotPrefix, routeConfig.Substr, routeConfig.NotSubstr, routeConfig.Regex, routeConfig.NotRegex, routeConfig.Project, routeConfig.Topic, format, codec, bufSize, flushMaxSize, flushMaxWait, routeConfig.Blocking)
 			if err != nil {
 				log.Error(err.Error())
 				return fmt.Errorf("error adding route '%s'", routeConfig.Key)
@@ -860,7 +869,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				storageResolution = routeConfig.StorageResolution
 			}
 
-			route, err := route.NewCloudWatch(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, awsProfile, awsRegion, awsNamespace, awsDimensions, bufSize, flushMaxSize, flushMaxWait, storageResolution, routeConfig.Blocking)
+			route, err := route.NewCloudWatch(routeConfig.Key, routeConfig.Prefix, routeConfig.NotPrefix, routeConfig.Substr, routeConfig.NotSubstr, routeConfig.Regex, routeConfig.NotRegex, awsProfile, awsRegion, awsNamespace, awsDimensions, bufSize, flushMaxSize, flushMaxWait, storageResolution, routeConfig.Blocking)
 			if err != nil {
 				log.Error(err.Error())
 				return fmt.Errorf("error adding route '%s'", routeConfig.Key)

--- a/ui/web/admin_http_assets/index.html
+++ b/ui/web/admin_http_assets/index.html
@@ -80,16 +80,22 @@
               <thead>
                 <tr>
                   <th>Match prefix</th>
+                  <th>Not match prefix</th>
                   <th>Match substring</th>
+                  <th>Not match substring</th>
                   <th>Match regex</th>
+                  <th>Not match regex</th>
                   <th>Actions</th>
                 </tr>
               </thead>
               <tbody ng-repeat="b in table.blacklist">
                 <tr>
                     <td>{{b.prefix}}</td>
+                    <td>{{b.notPrefix}}</td>
                     <td>{{b.substring}}</td>
+                    <td>{{b.notSubstring}}</td>
                     <td>{{b.regex}}</td>
+                    <td>{{b.notRegex}}</td>
                     <td class="text-center"><a ng-click="removeBlacklist($index)"><i class="glyphicon glyphicon-remove-circle"/></a></td>
                 </tr>
               </tbody>
@@ -217,8 +223,11 @@
                   <th>Route key</th>
                   <th>Route type</th>
                   <th>Match prefix</th>
+                  <th>Not match prefix</th>
                   <th>Match substring</th>
+                  <th>Not match substring</th>
                   <th>Match regex</th>
+                  <th>Not match regex</th>
                   <th>Address</th>
                   <th>Spool</th>
                   <th>Pickle</th>
@@ -231,8 +240,11 @@
                   <td class="info">{{r.key}}</td>
                   <td class="info">{{r.type}}</td>
                   <td class="info">{{r.matcher.prefix}}</td>
+                  <td class="info">{{r.matcher.notPrefix}}</td>
                   <td class="info">{{r.matcher.substring}}</td>
+                  <td class="info">{{r.matcher.notSubstring}}</td>
                   <td class="info">{{r.matcher.regex}}</td>
+                  <td class="info">{{r.matcher.notRegex}}</td>
                   <td class="info" colspan="3"></td>
                   <td class="info" colspan="2"><a ng-click="removeRoute(r.key)"><i class="glyphicon glyphicon-remove-circle"/></a></td>
                 </tr>
@@ -241,8 +253,11 @@
                     <td></td>
                     <td></td>
                     <td ng-class="{'danger': !d.online, 'info': d.online}">{{d.matcher.prefix}}</td>
+                    <td ng-class="{'danger': !d.online, 'info': d.online}">{{d.matcher.notPrefix}}</td>
                     <td ng-class="{'danger': !d.online, 'info': d.online}">{{d.matcher.substring}}</td>
+                    <td ng-class="{'danger': !d.online, 'info': d.online}">{{d.matcher.notSubstring}}</td>
                     <td ng-class="{'danger': !d.online, 'info': d.online}">{{d.matcher.regex}}</td>
+                    <td ng-class="{'danger': !d.online, 'info': d.online}">{{d.matcher.notRegex}}</td>
                     <td ng-class="{'danger': !d.online, 'info': d.online}">{{d.address}}</td>
                     <td ng-class="{'danger': !d.online, 'info': d.online}" class="text-center">
                     <icon ng-show="d.spool" class="glyphicon glyphicon-hdd"/>
@@ -269,10 +284,19 @@
                     <input ng-model="newRoute.Prefix" name="Prefix" class="form-control" placeholder="Prefix">
                   </td>
                   <td class="form-group has-feedback">
+                    <input ng-model="newRoute.NotPrefix" name="NotPrefix" class="form-control" placeholder="NotPrefix">
+                  </td>
+                  <td class="form-group has-feedback">
                     <input ng-model="newRoute.Substring" name="Substring" class="form-control" placeholder="Substring">
                   </td>
                   <td class="form-group has-feedback">
+                    <input ng-model="newRoute.NotSubstring" name="NotSubstring" class="form-control" placeholder="NotSubstring">
+                  </td>
+                  <td class="form-group has-feedback">
                     <input ng-model="newRoute.Regex" name="Regex" class="form-control" placeholder="Regex" ng-pattern="validRegex">
+                  </td>
+                  <td class="form-group has-feedback">
+                    <input ng-model="newRoute.NotRegex" name="Regex" class="form-control" placeholder="NotRegex" ng-pattern="validRegex">
                   </td>
                   <td class="form-group has-feedback">
                     <input ng-model="newRoute.Address" name="Address" class="form-control" required placeholder="Address" ng-pattern="validAddress">

--- a/ui/web/web.go
+++ b/ui/web/web.go
@@ -153,8 +153,11 @@ func parseRouteRequest(r *http.Request) (route.Route, *handlerError) {
 		Key                  string
 		Type                 string
 		Prefix               string
+		NotPrefix            string
 		Substring            string
+		NotSubstring         string
 		Regex                string
+		NotRegex             string
 		Address              string
 		Spool                bool
 		Pickle               bool
@@ -174,6 +177,9 @@ func parseRouteRequest(r *http.Request) (route.Route, *handlerError) {
 	}
 	dest, err := destination.New(
 		req.Key,
+		"",
+		"",
+		"",
 		"",
 		"",
 		"",
@@ -200,9 +206,9 @@ func parseRouteRequest(r *http.Request) (route.Route, *handlerError) {
 	var e error
 	switch req.Type {
 	case "sendAllMatch":
-		ro, e = route.NewSendAllMatch(req.Key, req.Prefix, req.Substring, req.Regex, []*destination.Destination{dest})
+		ro, e = route.NewSendAllMatch(req.Key, req.Prefix, req.NotPrefix, req.Substring, req.NotSubstring, req.Regex, req.NotRegex, []*destination.Destination{dest})
 	case "sendFirstMatch":
-		ro, e = route.NewSendFirstMatch(req.Key, req.Prefix, req.Substring, req.Regex, []*destination.Destination{dest})
+		ro, e = route.NewSendFirstMatch(req.Key, req.Prefix, req.NotPrefix, req.Substring, req.NotSubstring, req.Regex, req.NotRegex, []*destination.Destination{dest})
 	default:
 		return nil, &handlerError{nil, "unknown route type: " + req.Type, http.StatusBadRequest}
 	}
@@ -214,20 +220,23 @@ func parseRouteRequest(r *http.Request) (route.Route, *handlerError) {
 
 func parseAggregateRequest(r *http.Request) (*aggregator.Aggregator, *handlerError) {
 	var request struct {
-		Fun       string
-		OutFmt    string
-		Cache     bool
-		Interval  uint
-		Wait      uint
-		DropRaw   bool
-		Regex     string
-		Prefix    string `json:"omitempty"`
-		Substring string `json:"omitempty"`
+		Fun          string
+		OutFmt       string
+		Cache        bool
+		Interval     uint
+		Wait         uint
+		DropRaw      bool
+		Regex        string `json:"regex,omitempty"`
+		NotRegex     string `json:"notRegex,omitempty"`
+		Prefix       string `json:"prefix,omitempty"`
+		NotPrefix    string `json:"notPrefix,omitempty"`
+		Substring    string `json:"substring,omitempty"`
+		NotSubstring string `json:"notSubstring,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return nil, &handlerError{err, "Couldn't parse json", http.StatusBadRequest}
 	}
-	aggregate, err := aggregator.New(request.Fun, request.Regex, request.Prefix, request.Substring, request.OutFmt, request.Cache, request.Interval, request.Wait, request.DropRaw, table.In)
+	aggregate, err := aggregator.New(request.Fun, request.Regex, request.NotRegex, request.Prefix, request.NotPrefix, request.Substring, request.NotSubstring, request.OutFmt, request.Cache, request.Interval, request.Wait, request.DropRaw, table.In)
 	if err != nil {
 		return nil, &handlerError{err, "Couldn't create aggregator", http.StatusBadRequest}
 	}


### PR DESCRIPTION
This is a simplified alternative to the PR #421 

It implements the same functionality, but it uses a more traditional approach for the matcher struct.

Fixes #413
Closes #421 