### PR TITLE
add inverted matchers to docs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -21,8 +21,11 @@ Examples:
 # aggregate timer metrics with sums
 function = 'sum'
 prefix = ''
+notPrefix = ''
 sub = ''
+notSub = ''
 regex = '^stats\.timers\.(app|proxy|static)[0-9]+\.requests\.(.*)'
+notRegex = ''
 format = 'stats.timers._sum_$1.requests.$2'
 interval = 10
 wait = 20
@@ -31,8 +34,11 @@ wait = 20
 # aggregate timer metrics with averages
 function = 'avg'
 prefix = ''
+notPrefix = ''
 sub = 'requests'
+notSub = ''
 regex = '^stats\.timers\.(app|proxy|static)[0-9]+\.requests\.(.*)'
+notRegex = ''
 format = 'stats.timers._avg_$1.requests.$2'
 interval = 5
 wait = 10
@@ -44,8 +50,11 @@ cache = true
 # pxx gets appended to the corresponding metric path.
 function = 'percentiles'
 prefix = ''
+notPrefix = ''
 sub = 'requests'
+notSub = ''
 regex = '^stats\.timers\.(app|proxy|static)[0-9]+\.requests\.(.*)'
+notRegex = ''
 format = 'stats.timers.$1.requests.$2'
 interval = 5
 wait = 10
@@ -68,13 +77,16 @@ max = -1
 
 ## carbon route
 
-setting | mandatory | values                                        | default | description
---------|-----------|-----------------------------------------------|---------|------------
-key     |     Y     | string                                        | N/A     |
-type    |     Y     | sendAllMatch/sendFirstMatch/consistentHashing | N/A     | send to all destinations vs first matching destination vs distribute via consistent hashing
-prefix  |     N     | string                                        | ""      |
-sub     |     N     | string                                        | ""      |
-regex   |     N     | string                                        | ""      |
+setting        | mandatory | values                                        | default | description
+---------------|-----------|-----------------------------------------------|---------|------------
+key            |     Y     | string                                        | N/A     |
+type           |     Y     | sendAllMatch/sendFirstMatch/consistentHashing | N/A     | send to all destinations vs first matching destination vs distribute via consistent hashing
+prefix         |     N     | string                                        | ""      |
+notPrefix      |     N     | string                                        | ""      |
+sub            |     N     | string                                        | ""      |
+notSub         |     N     | string                                        | ""      |
+regex          |     N     | string                                        | ""      |
+notRegex       |     N     | string                                        | ""      |
 
 ### Examples
 
@@ -84,8 +96,11 @@ regex   |     N     | string                                        | ""      |
 key = 'carbon-default'
 type = 'sendAllMatch'
 # prefix = ''
+# notPrefix = ''
 # sub = ''
+# notSub = ''
 # regex = ''
+# notRegex = ''
 destinations = [
   '127.0.0.1:2003 spool=true pickle=false'
 ]
@@ -116,8 +131,11 @@ setting              | mandatory | values        | default | description
 ---------------------|-----------|---------------|---------|------------
 addr                 |     Y     |  string       | N/A     |
 prefix               |     N     |  string       | ""      |
+notPrefix            |     N     |  string       | ""      |
 sub                  |     N     |  string       | ""      |
+notSub               |     N     |  string       | ""      |
 regex                |     N     |  string       | ""      |
+notRegex             |     N     |  string       | ""      |
 flush                |     N     |  int (ms)     | 1000    | flush interval
 reconn               |     N     |  int (ms)     | 10k     | reconnection interval
 pickle               |     N     |  true/false   | false   | pickle output format instead of the default text protocol
@@ -140,8 +158,11 @@ addr           |     Y     |  string     | N/A     |
 apiKey         |     Y     |  string     | N/A     |
 schemasFile    |     Y     |  string     | N/A     |
 prefix         |     N     |  string     | ""      |
+notPrefix      |     N     |  string     | ""      |
 sub            |     N     |  string     | ""      |
+notSub         |     N     |  string     | ""      |
 regex          |     N     |  string     | ""      |
+notRegex       |     N     |  string     | ""      |
 sslverify      |     N     |  true/false | true    |
 spool          |     N     |  true/false | false   | ** disk spooling. not implemented yet **
 blocking       |     N     |  true/false | false   | if false, full buffer drops data. if true, full buffer puts backpressure on the table, possibly affecting ingestion and other routes
@@ -198,8 +219,11 @@ codec          |     Y     |  string     | N/A     | which compression to use. p
 partitionBy    |     Y     |  string     | N/A     | which fields to shard by. possible values are: byOrg, bySeries, bySeriesWithTags
 schemasFile    |     Y     |  string     | N/A     |
 prefix         |     N     |  string     | ""      |
+notPrefix      |     N     |  string     | ""      |
 sub            |     N     |  string     | ""      |
+notSub         |     N     |  string     | ""      |
 regex          |     N     |  string     | ""      |
+notRegex       |     N     |  string     | ""      |
 blocking       |     N     |  true/false | false   | if false, full buffer drops data. if true, full buffer puts backpressure on the table, possibly affecting ingestion and other routes
 bufSize        |     N     |  int        | 10M     | buffer size. assume +- 100B per message, so 10M is about 1GB of RAM
 flushMaxNum    |     N     |  int        | 10k     | max number of metrics to buffer before triggering flush
@@ -216,8 +240,11 @@ project        |     Y     |  string     | N/A           | Google Cloud Project 
 topic          |     Y     |  string     | N/A           | The Google PubSub topic to publish metrics onto
 codec          |     N     |  string     | gzip          | Optional compression codec to compress published messages. Valid: "none" (no compression), "gzip" (default)
 prefix         |     N     |  string     | ""            |
+notPrefix      |     N     |  string     | ""            |
 sub            |     N     |  string     | ""            |
+notSub         |     N     |  string     | ""            |
 regex          |     N     |  string     | ""            |
+notRegex       |     N     |  string     | ""            |
 blocking       |     N     |  true/false | false         | if false, full buffer drops data. if true, full buffer puts backpressure on the table, possibly affecting ingestion and other routes
 bufSize        |     N     |  int        | 10M           | buffer size. assume +- 100B per message, so 10M is about 1GB of RAM
 flushMaxSize   |     N     |  int        | (10MB - 4KB)  | max message size before triggering flush. The size is before any compression is calculated. PubSub message limit is 10MB but this can be higher if using compression.
@@ -231,8 +258,11 @@ key              |     Y     |  string     | N/A           |
 profile          |     N     |  string     | N/A           | The Amazon CloudWatch profile to use. For local development needed only. In the cloud, the profile is known.
 region           |     Y     |  string     | N/A           | The Amazon Geo region to send metrics into.
 prefix           |     N     |  string     | ""            |
+notPrefix        |     N     |  string     | ""            |
 sub              |     N     |  string     | ""            |
+notSub           |     N     |  string     | ""            |
 regex            |     N     |  string     | ""            |
+notRegex         |     N     |  string     | ""            |
 blocking         |     N     |  true/false | false         | if false, full buffer drops data. if true, full buffer puts backpressure on the table, possibly affecting ingestion and other routes.
 bufSize          |     N     |  int        | 10M           | buffer size. assume +- 100B per message, so 10M is about 1GB of RAM.
 flushMaxSize     |     N     |  int        | 20            | max MetricDatum objects in slice before triggering flush. 20 is currently the CloudWatch max.

--- a/docs/grafana-net.md
+++ b/docs/grafana-net.md
@@ -25,15 +25,18 @@ notes:
 * by specifying a prefix, sub or regex you can only send a subset of your metrics to grafana.com hosted metrics
 
 ```
-addRoute grafanaNet key [prefix/sub/regex]  addr apiKey schemasFile [spool=true/false sslverify=true/false bufSize=int flushMaxNum=int flushMaxWait=int timeout=int]")
+addRoute grafanaNet key [prefix/notPrefix/sub/notSub/regex/notRegex]  addr apiKey schemasFile [spool=true/false sslverify=true/false bufSize=int flushMaxNum=int flushMaxWait=int timeout=int]")
 ```
 
 
 ### matching options
 
 substring match: `addRoute grafanaNet grafanaNet sub=<substring here>  addr...`
-regex match: `addRoute grafanaNet grafanaNet regex=your-regex-here  addr...`
-prefix match: `addRoute grafanaNet grafanaNet prefix=prefix-match-here  addr...`
+inverted substring match: `addRoute grafanaNet grafanaNet notSub=<substring here>  addr...`
+regex match: `addRoute grafanaNet grafanaNet regex=<regex here>  addr...`
+inverted regex match: `addRoute grafanaNet grafanaNet notRegex=<your regex>  addr...`
+prefix match: `addRoute grafanaNet grafanaNet prefix=<prefix here>  addr...`
+inverted prefix match: `addRoute grafanaNet grafanaNet notPrefix=<prefix here>  addr...`
 
 the options can also be combined (space separated). note two spaces before the address!
 

--- a/docs/tcp-admin-interface.md
+++ b/docs/tcp-admin-interface.md
@@ -27,8 +27,11 @@ commands:
                sum
              <match>
                regex=<str>                       mandatory. regex to match incoming metrics. supports groups (numbered, see fmt)
+               notRegex=<str>                    regex to check against incoming metrics, inverted (only metrics where the regex doesn't match pass)
                sub=<str>                         substring to match incoming metrics before matching regex (can save you CPU)
+               notSub=<str>                      inverted substring filter, metrics which do not contain this string pass the filter
                prefix=<str>                      prefix to match incoming metrics before matching regex (can save you CPU). If not specified, will try to automatically determine from regex.
+               notPrefix=<str>                   inverted prefix filter, metrics which do not start with this string pass the filter
              <fmt>                               format of output metric. you can use $1, $2, etc to refer to numbered groups
              <interval>                          align odd timestamps of metrics into buckets by this interval in seconds.
              <wait>                              amount of seconds to wait for "late" metric messages before computing and flushing final result.
@@ -41,8 +44,11 @@ commands:
                consistentHashing                 distribute metrics between destinations using a hash algorithm
              <opts>:
                prefix=<str>                      only take in metrics that have this prefix
+               notPrefix=<str>                   only take in metrics that don't have this prefix
                sub=<str>                         only take in metrics that match this substring
+               notSub=<str>                      only take in metrics that don't match this substring
                regex=<regex>                     only take in metrics that match this regex (expensive!)
+               notRegex=<regex>                  only take in metrics that don't match this regex (expensive!)
              <dest>: <addr> <opts>
                <addr>                            a tcp endpoint. i.e. ip:port or hostname:port
                                                  for consistentHashing routes, an instance identifier can also be present:
@@ -50,8 +56,11 @@ commands:
                                                  The instance is used to disambiguate multiple endpoints on the same host, as the Carbon-compatible consistent hashing algorithm does not take the port into account.
                <opts>:
                    prefix=<str>                  only take in metrics that have this prefix
+                   notPrefix=<str>               only take in metrics that don't have this prefix
                    sub=<str>                     only take in metrics that match this substring
+                   notSub=<str>                  only take in metrics that don't match this substring
                    regex=<regex>                 only take in metrics that match this regex (expensive!)
+                   notRegex=<regex>              only take in metrics that don't match this regex (expensive!)
                    flush=<int>                   flush interval in ms
                    reconn=<int>                  reconnection interval in ms
                    pickle={true,false}           pickle output format instead of the default text protocol
@@ -72,12 +81,18 @@ commands:
     modDest <routeKey> <dest> <opts>:            modify dest by updating one or more space separated option strings
                    addr=<addr>                   new tcp address
                    prefix=<str>                  new matcher prefix
+                   notPrefix=<str>               new matcher not prefix
                    sub=<str>                     new matcher substring
+                   notSub=<str>                  new matcher not substring
                    regex=<regex>                 new matcher regex
+                   notRegex=<regex>              new matcher not regex
 
     modRoute <routeKey> <opts>:                  modify route by updating one or more space separated option strings
                    prefix=<str>                  new matcher prefix
+                   notPrefix=<str>               new matcher not prefix
                    sub=<str>                     new matcher substring
+                   notSub=<str>                  new matcher not substring
                    regex=<regex>                 new matcher regex
+                   notRegex=<regex>              new matcher not regex
 
     delRoute <routeKey>                          delete given route


### PR DESCRIPTION
Adds docs for the inverted matcher conditions.

Depends on this PR to get merged, otherwise the docs are showing wrong examples: https://github.com/grafana/carbon-relay-ng/pull/419