### PR TITLE
Kafkamdm TLS + SASL

### DIFF
--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -99,10 +99,14 @@ type Route struct {
 	Concurrency int
 
 	// kafkaMdm
-	Brokers     []string
-	Topic       string // also used by Google PubSub
-	Codec       string // also used by Google PubSub
-	PartitionBy string
+	Brokers       []string
+	Topic         string // also used by Google PubSub
+	Codec         string // also used by Google PubSub
+	PartitionBy   string
+	TLSEnabled    bool   `toml:"tls_enabled"`
+	TLSSkipVerify bool   `toml:"tls_skip_verify"`
+	TLSClientCert string `toml:"tls_client_cert"`
+	TLSClientKey  string `toml:"tls_client_key"`
 
 	// Google PubSub
 	Project      string

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -103,10 +103,13 @@ type Route struct {
 	Topic         string // also used by Google PubSub
 	Codec         string // also used by Google PubSub
 	PartitionBy   string
-	TLSEnabled    bool   `toml:"tls_enabled"`
-	TLSSkipVerify bool   `toml:"tls_skip_verify"`
-	TLSClientCert string `toml:"tls_client_cert"`
-	TLSClientKey  string `toml:"tls_client_key"`
+	TLSEnabled    bool
+	TLSSkipVerify bool
+	TLSClientCert string
+	TLSClientKey  string
+	SASLEnabled   bool
+	SASLUsername  string
+	SASLPassword  string
 
 	// Google PubSub
 	Project      string

--- a/docs/config.md
+++ b/docs/config.md
@@ -206,6 +206,25 @@ flushMaxNum    |     N     |  int        | 10k     | max number of metrics to bu
 flushMaxWait   |     N     |  int (ms)   | 500     | max time to buffer before triggering flush
 timeout        |     N     |  int (ms)   | 2000    |
 orgId          |     N     |  int        | 1       |
+tls_enabled    |     N     |  bool       | false   | Whether to enable TLS
+tls_skip_verify|     N     |  bool       | false   | Whether to skip TLS server cert verification
+tls_client_cert|     N     |  string     | ""      | Client cert for client authentication (use with tls_enabled and tls_client_key)
+tls_client_key |     N     |  string     | ""      | Client key for client authentication (use with tls_enabled and tls_client_cert)
+
+example config with TLS enabled:
+
+```
+[[route]]
+key = 'my-kafka-route'    
+type = 'kafkaMdm'
+brokers = ['kafka:9092']
+topic = 'mdm'
+codec = 'snappy'
+partitionBy = 'bySeriesWithTags'
+schemasFile = 'conf/storage-schemas.conf'
+tls_enabled = true  
+tls_skip_verify  = false
+```
 
 ## Google PubSub route
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -206,10 +206,13 @@ flushMaxNum    |     N     |  int        | 10k     | max number of metrics to bu
 flushMaxWait   |     N     |  int (ms)   | 500     | max time to buffer before triggering flush
 timeout        |     N     |  int (ms)   | 2000    |
 orgId          |     N     |  int        | 1       |
-tls_enabled    |     N     |  bool       | false   | Whether to enable TLS
-tls_skip_verify|     N     |  bool       | false   | Whether to skip TLS server cert verification
-tls_client_cert|     N     |  string     | ""      | Client cert for client authentication (use with tls_enabled and tls_client_key)
-tls_client_key |     N     |  string     | ""      | Client key for client authentication (use with tls_enabled and tls_client_cert)
+tlsEnabled     |     N     |  bool       | false   | Whether to enable TLS
+tlsSkipVerify  |     N     |  bool       | false   | Whether to skip TLS server cert verification
+tlsClientCert  |     N     |  string     | ""      | Client cert for client authentication
+tlsClientKey   |     N     |  string     | ""      | Client key for client authentication
+saslEnabled    |     N     |  bool       | false   | Whether to enable SASL
+saslUsername   |     N     |  string     | ""      | SASL Username
+saslPassword   |     N     |  string     | ""      | SASL Password
 
 example config with TLS enabled:
 
@@ -222,8 +225,8 @@ topic = 'mdm'
 codec = 'snappy'
 partitionBy = 'bySeriesWithTags'
 schemasFile = 'conf/storage-schemas.conf'
-tls_enabled = true  
-tls_skip_verify  = false
+tlsEnabled = true
+tlsSkipVerify  = false
 ```
 
 ## Google PubSub route

--- a/imperatives/imperatives.go
+++ b/imperatives/imperatives.go
@@ -61,6 +61,10 @@ const (
 	optSpoolSyncEvery
 	optSpoolSyncPeriod
 	optSpoolSleep
+	optTLSEnabled
+	optTLSSkipVerify
+	optTLSClientCert
+	optTLSClientKey
 	optUnspoolSleep
 	optPickle
 	optSpool
@@ -117,6 +121,10 @@ var tokens = []toki.Def{
 	{Token: optSpoolSyncEvery, Pattern: "spoolsyncevery="},
 	{Token: optSpoolSyncPeriod, Pattern: "spoolsyncperiod="},
 	{Token: optSpoolSleep, Pattern: "spoolsleep="},
+	{Token: optTLSEnabled, Pattern: "tls_enabled="},
+	{Token: optTLSSkipVerify, Pattern: "tls_skip_verify="},
+	{Token: optTLSClientCert, Pattern: "tls_client_cert="},
+	{Token: optTLSClientKey, Pattern: "tls_client_key="},
 	{Token: optUnspoolSleep, Pattern: "unspoolsleep="},
 	{Token: optPickle, Pattern: "pickle="},
 	{Token: optSpool, Pattern: "spool="},
@@ -155,7 +163,7 @@ var errFmtAddBlack = errors.New("addBlack <prefix|sub|regex> <pattern>")
 var errFmtAddAgg = errors.New("addAgg <avg|count|delta|derive|last|max|min|stdev|sum> [prefix/sub/regex=,..] <fmt> <interval> <wait> [cache=true/false] [dropRaw=true/false]")
 var errFmtAddRoute = errors.New("addRoute <type> <key> [prefix/sub/regex=,..]  <dest>  [<dest>[...]] where <dest> is <addr> [prefix/sub,regex,flush,reconn,pickle,spool=...]") // note flush and reconn are ints, pickle and spool are true/false. other options are strings
 var errFmtAddRouteGrafanaNet = errors.New("addRoute grafanaNet key [prefix/sub/regex=,...]  addr apiKey schemasFile [spool=true/false sslverify=true/false blocking=true/false bufSize=int flushMaxNum=int flushMaxWait=int timeout=int concurrency=int orgId=int]")
-var errFmtAddRouteKafkaMdm = errors.New("addRoute kafkaMdm key [prefix/sub/regex=,...]  broker topic codec schemasFile partitionBy orgId [blocking=true/false bufSize=int flushMaxNum=int flushMaxWait=int timeout=int]")
+var errFmtAddRouteKafkaMdm = errors.New("addRoute kafkaMdm key [prefix/sub/regex=,...]  broker topic codec schemasFile partitionBy orgId [blocking=true/false bufSize=int flushMaxNum=int flushMaxWait=int timeout=int tls_enabled=bool tls_skip_verify=bool tls_client_key='<key>' tls_client_cert='<file>']")
 var errFmtAddRoutePubSub = errors.New("addRoute pubsub key [prefix/sub/regex=,...]  project topic [codec=gzip/none format=plain/pickle blocking=true/false bufSize=int flushMaxSize=int flushMaxWait=int]")
 var errFmtAddDest = errors.New("addDest <routeKey> <dest>") // not implemented yet
 var errFmtAddRewriter = errors.New("addRewriter <old> <new> <max>")
@@ -680,6 +688,8 @@ func readAddRouteKafkaMdm(s *toki.Scanner, table Table) error {
 	var flushMaxWait = 500  // in ms
 	var timeout = 2000      // in ms
 	var blocking = false
+	var tlsEnabled, tlsSkipVerify bool
+	var tlsClientCert, tlsClientKey string
 
 	t = s.Next()
 	for ; t.Token != toki.EOF; t = s.Next() {
@@ -734,12 +744,44 @@ func readAddRouteKafkaMdm(s *toki.Scanner, table Table) error {
 			} else {
 				return errFmtAddRouteKafkaMdm
 			}
+		case optTLSEnabled:
+			t = s.Next()
+			if t.Token == optTrue || t.Token == optFalse {
+				tlsEnabled, err = strconv.ParseBool(string(t.Value))
+				if err != nil {
+					return err
+				}
+			} else {
+				return errFmtAddRouteKafkaMdm
+			}
+		case optTLSSkipVerify:
+			t = s.Next()
+			if t.Token == optTrue || t.Token == optFalse {
+				tlsSkipVerify, err = strconv.ParseBool(string(t.Value))
+				if err != nil {
+					return err
+				}
+			} else {
+				return errFmtAddRouteKafkaMdm
+			}
+		case optTLSClientCert:
+			t = s.Next()
+			if t.Token != word {
+				return errFmtAddRouteKafkaMdm
+			}
+			tlsClientCert = string(t.Value)
+		case optTLSClientKey:
+			t = s.Next()
+			if t.Token != word {
+				return errFmtAddRouteKafkaMdm
+			}
+			tlsClientKey = string(t.Value)
 		default:
 			return fmt.Errorf("unexpected token %d %q", t.Token, t.Value)
 		}
 	}
 
-	route, err := route.NewKafkaMdm(key, matcher, topic, codec, schemasFile, partitionBy, brokers, bufSize, orgId, flushMaxNum, flushMaxWait, timeout, blocking)
+	route, err := route.NewKafkaMdm(key, matcher, topic, codec, schemasFile, partitionBy, brokers, bufSize, orgId, flushMaxNum, flushMaxWait, timeout, blocking, tlsEnabled, tlsSkipVerify, tlsClientCert, tlsClientKey)
 	if err != nil {
 		return err
 	}

--- a/route/kafkamdm.go
+++ b/route/kafkamdm.go
@@ -7,17 +7,17 @@ import (
 	"time"
 
 	"github.com/Dieterbe/go-metrics"
-	"github.com/Shopify/sarama/tools/tls"
-	dest "github.com/grafana/carbon-relay-ng/destination"
-	"github.com/grafana/carbon-relay-ng/matcher"
-	"github.com/grafana/carbon-relay-ng/stats"
-	"github.com/grafana/carbon-relay-ng/util"
-	log "github.com/sirupsen/logrus"
-
 	"github.com/Shopify/sarama"
-	"github.com/grafana/carbon-relay-ng/persister"
+	"github.com/Shopify/sarama/tools/tls"
 	"github.com/grafana/metrictank/cluster/partitioner"
 	"github.com/grafana/metrictank/schema"
+	log "github.com/sirupsen/logrus"
+
+	dest "github.com/grafana/carbon-relay-ng/destination"
+	"github.com/grafana/carbon-relay-ng/matcher"
+	"github.com/grafana/carbon-relay-ng/persister"
+	"github.com/grafana/carbon-relay-ng/stats"
+	"github.com/grafana/carbon-relay-ng/util"
 )
 
 type KafkaMdm struct {
@@ -52,7 +52,7 @@ type KafkaMdm struct {
 
 // NewKafkaMdm creates a special route that writes to a grafana.net datastore
 // We will automatically run the route and the destination
-func NewKafkaMdm(key string, matcher matcher.Matcher, topic, codec, schemasFile, partitionBy string, brokers []string, bufSize, orgId, flushMaxNum, flushMaxWait, timeout int, blocking bool, tlsEnabled, tlsSkipVerify bool, tlsClientCert, tlsClientKey string) (Route, error) {
+func NewKafkaMdm(key string, matcher matcher.Matcher, topic, codec, schemasFile, partitionBy string, brokers []string, bufSize, orgId, flushMaxNum, flushMaxWait, timeout int, blocking bool, tlsEnabled, tlsSkipVerify bool, tlsClientCert, tlsClientKey string, saslEnabled bool, saslUsername, saslPassword string) (Route, error) {
 	schemas, err := getSchemas(schemasFile)
 	if err != nil {
 		return nil, err
@@ -110,6 +110,12 @@ func NewKafkaMdm(key string, matcher matcher.Matcher, topic, codec, schemasFile,
 		config.Net.TLS.Enable = true
 		config.Net.TLS.Config = tlsConfig
 		config.Net.TLS.Config.InsecureSkipVerify = tlsSkipVerify
+	}
+
+	if saslEnabled {
+		config.Net.SASL.Enable = true
+		config.Net.SASL.User = saslUsername
+		config.Net.SASL.Password = saslPassword
 	}
 
 	config.Producer.RequiredAcks = sarama.WaitForAll // Wait for all in-sync replicas to ack the message

--- a/table/table.go
+++ b/table/table.go
@@ -832,7 +832,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				orgId = routeConfig.OrgId
 			}
 
-			route, err := route.NewKafkaMdm(routeConfig.Key, matcher, routeConfig.Topic, routeConfig.Codec, routeConfig.SchemasFile, routeConfig.PartitionBy, routeConfig.Brokers, bufSize, orgId, flushMaxNum, flushMaxWait, timeout, routeConfig.Blocking)
+			route, err := route.NewKafkaMdm(routeConfig.Key, matcher, routeConfig.Topic, routeConfig.Codec, routeConfig.SchemasFile, routeConfig.PartitionBy, routeConfig.Brokers, bufSize, orgId, flushMaxNum, flushMaxWait, timeout, routeConfig.Blocking, routeConfig.TLSEnabled, routeConfig.TLSSkipVerify, routeConfig.TLSClientCert, routeConfig.TLSClientKey)
 			if err != nil {
 				log.Error(err.Error())
 				return fmt.Errorf("error adding route '%s'", routeConfig.Key)

--- a/table/table.go
+++ b/table/table.go
@@ -832,7 +832,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				orgId = routeConfig.OrgId
 			}
 
-			route, err := route.NewKafkaMdm(routeConfig.Key, matcher, routeConfig.Topic, routeConfig.Codec, routeConfig.SchemasFile, routeConfig.PartitionBy, routeConfig.Brokers, bufSize, orgId, flushMaxNum, flushMaxWait, timeout, routeConfig.Blocking, routeConfig.TLSEnabled, routeConfig.TLSSkipVerify, routeConfig.TLSClientCert, routeConfig.TLSClientKey)
+			route, err := route.NewKafkaMdm(routeConfig.Key, matcher, routeConfig.Topic, routeConfig.Codec, routeConfig.SchemasFile, routeConfig.PartitionBy, routeConfig.Brokers, bufSize, orgId, flushMaxNum, flushMaxWait, timeout, routeConfig.Blocking, routeConfig.TLSEnabled, routeConfig.TLSSkipVerify, routeConfig.TLSClientCert, routeConfig.TLSClientKey, routeConfig.SASLEnabled, routeConfig.SASLUsername, routeConfig.SASLPassword)
 			if err != nil {
 				log.Error(err.Error())
 				return fmt.Errorf("error adding route '%s'", routeConfig.Key)


### PR DESCRIPTION
I'm using Confluent Cloud, which requires SASL auth. This PR takes @Dieterbe's changes for TLS, adds SASL options, and alters params to follow naming conventions.