### PR TITLE
Document k8s deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Documentation
 * [current changelog](https://github.com/grafana/carbon-relay-ng/blob/master/CHANGELOG.md) and [official releasess](https://github.com/grafana/carbon-relay-ng/releases)
 * [limitations](https://github.com/grafana/carbon-relay-ng/blob/master/docs/limitations.md)
 * [installation and building](https://github.com/grafana/carbon-relay-ng/blob/master/docs/installation-building.md)
+* [Deploying on Kubernetes](https://github.com/grafana/carbon-relay-ng/blob/master/docs/deploying-on-k8s.md)
 
 
 Concepts

--- a/docs/deploying-on-k8s.md
+++ b/docs/deploying-on-k8s.md
@@ -52,3 +52,7 @@ $ tk show env
 ```
 
 # Applying the YAML files
+For users who don't use ksonnet yet, we also provide yaml files which can be used as templates to
+create the necessary resources to deploy carbon-relay-ng.
+
+The yaml files are in the directory [/examples/k8s](https://github.com/grafana/carbon-relay-ng/tree/document_k8s_deployment/examples/k8s).

--- a/docs/deploying-on-k8s.md
+++ b/docs/deploying-on-k8s.md
@@ -1,0 +1,54 @@
+# Deploying Carbon-Relay-Ng on Kubernetes
+
+We support two methods of deploying Carbon-Relay-Ng onto Kubernetes, 
+via Ksonnet/Tanka and by directly applying the provided `.yaml` files.
+
+# Ksonnet/Tanka
+
+In this repository in `/ksonnet/lib/carbon-relay-ng` we provide a mixin which can be used in 
+ksonnet to create a simple carbon-relay-ng deployment. 
+Note that the mixin depends on the [ksonnet-util library](https://github.com/grafana/jsonnet-libs/tree/master/ksonnet-util).
+
+Using the jsonnet bundler and ksonnet, a simple carbon-relay-ng deployment can be created like shown here:
+
+```
+# if jb isn't already initialized
+jb init
+
+# install the carbon-relay-ng mixin,
+# this will also install the dependency github.com/grafana/jsonnet-libs/ksonnet-util
+jb install 'github.com/grafana/carbon-relay-ng/ksonnet/lib/carbon-relay-ng@document_k8s_deployment'
+
+# note that the ksonnet-util library depends on the file 'k.libsonnet' being available in
+# the jsonnet search path, if you don't already have that then it needs to be made available
+jb install github.com/ksonnet/ksonnet-lib/ksonnet.beta.4
+echo "import 'ksonnet.beta.4/k.libsonnet'" > $JSONNET_PATH/k.libsonnet
+
+# now you can use the mixin in ksonnet,
+# this is how an example env with configuration could look like
+$ cat env/main.jsonnet
+local k = import 'ksonnet-util/kausal.libsonnet';
+local crng = import 'carbon-relay-ng/crng.libsonnet';
+
+k + crng + {
+  _images+:: {
+  },
+  _config+:: {
+    namespace: 'mynamespace',
+    crng_route_host: 'https://tsdb-1-<instance name>.hosted-metrics.grafana.net/metrics',
+    crng_user_id: 'api_key',
+    crng_api_key: '<base64 api key>'
+  }
+}
+
+# generating the resource definitions, using tanka's tk command.
+# this should output 4 resources:
+#   a secret with the base64 encoded api key
+#   a configmap with the carbon-relay-ng.ini and storage-schemas.conf
+#   a service which forwards to the carbon-relay-ng pod
+#   a deployment creating the carbon-relay-ng pod
+$ tk show env
+
+```
+
+# Applying the YAML files

--- a/examples/k8s/configmap.yaml
+++ b/examples/k8s/configmap.yaml
@@ -1,0 +1,148 @@
+apiVersion: v1
+data:
+  carbon-relay-ng.ini: |
+    ## Global settings ##
+
+    # instance id's distinguish stats of multiple relays.
+    # do not run multiple relays with the same instance id.
+    # supported variables:
+    #  ${HOST} : hostname
+    instance = "${HOST}"
+
+    ## System ##
+    # this setting can be used to override the default GOMAXPROCS logic
+    # it is ignored if the GOMAXPROCS environment variable is set
+    # max_procs = 2
+    pid_file = "/tmp/carbon-relay-ng.pid"
+    # directory for spool files
+    spool_dir = "/tmp/carbon-relay-ng"
+
+    ## Logging ##
+    # one of trace debug info warn error fatal panic
+    # see docs/logging.md for level descriptions
+    # note: if you used to use `notice`, you should now use `info`.
+    log_level = "trace"
+
+    ## Admin ##
+    admin_addr = "0.0.0.0:2004"
+    http_addr = "0.0.0.0:8081"
+
+    ## Inputs ##
+    ### plaintext Carbon ###
+    listen_addr = "0.0.0.0:2003"
+    # close inbound plaintext connections if they've been idle for this long ("0s" to disable)
+    plain_read_timeout = "2m"
+    ### Pickle Carbon ###
+    pickle_addr = "0.0.0.0:2013"
+    # close inbound pickle connections if they've been idle for this long ("0s" to disable)
+    pickle_read_timeout = "2m"
+
+    ## Validation of inputs ##
+    # Metric name validation strictness for legacy metrics. Valid values are:
+    # strict - Block anything that can upset graphite: valid characters are [A-Za-z0-9_-.]; consecutive dots are not allowed
+    # medium - Valid characters are ASCII; no embedded NULLs
+    # none   - No validation is performed
+    validation_level_legacy = "medium"
+    # Metric validation for carbon2.0 (metrics2.0) metrics.
+    # Metrics that contain = or _is_ are assumed carbon2.0.
+    # Valid values are:
+    # medium - checks for unit and mtype tag, presence of another tag, and constency (use = or _is_, not both)
+    # none   - No validation is performed
+    validation_level_m20 = "medium"
+
+    # you can also validate that each series has increasing timestamps
+    validate_order = false
+
+    # How long to keep track of invalid metrics seen
+    # Useful time units are "s", "m", "h"
+    bad_metrics_max_age = "24h"
+
+    # Aggregators
+    # See https://github.com/grafana/carbon-relay-ng/blob/master/docs/config.md#Aggregators
+
+    # Rewriters
+    # See https://github.com/grafana/carbon-relay-ng/blob/master/docs/config.md#Rewriters
+
+    # Routes
+    # See https://github.com/grafana/carbon-relay-ng/blob/master/docs/config.md#Routes
+
+    [init]
+    # init commands (DEPRECATED)
+    # see https://github.com/grafana/carbon-relay-ng/blob/master/docs/config.md#Imperatives
+    cmds = [
+    ]
+
+    ## Instrumentation ##
+
+    [instrumentation]
+    # in addition to serving internal metrics via expvar, you can send them to graphite/carbon
+    # IMPORTANT: setting this to "" will disable flushing, and metrics will pile up and lead to OOM
+    # see https://github.com/grafana/carbon-relay-ng/issues/50
+    # so for now you MUST send them somewhere. sorry.
+    # (Also, the interval here must correspond to your setting in storage-schemas.conf if you use grafana hosted metrics)
+    #graphite_addr = "localhost:2003"
+    #graphite_interval = 10000  # in ms
+
+    # we prefix every raw metric with the string 'rawMetric.' because further down in the
+    # aggregators we want to be able to only ingest the raw metrics and not the outputs of
+    # the aggregators
+    #[[rewriter]]
+    #old = '/^/'
+    #new = 'rawMetric.'
+    #not = ''
+    #max = -1
+
+    # ingest all metrics prefixed with 'rawMetric.' and generate averaged aggregates
+    # which are suffixed with the string '.avg'
+    #[[aggregation]]
+    #function = 'avg'
+    #prefix = ''
+    #substr = ''
+    ## capture the name excluding the 'rawMetric.' prefix
+    #regex = '^(.*)$'
+    ## use the captured metric name and suffix it with '.avg'
+    #format = '$1.avg'
+    #interval = 10
+    #wait = 15
+    ## do not drop the raw data, as we still need it for the next aggregator
+    #dropRaw = false
+    #
+    ## ingest all metrics prefixed with 'rawMetric.' and generate summed aggregates
+    ## which are suffixed with the string '.sum'
+    #[[aggregation]]
+    #function = 'sum'
+    #prefix = ''
+    #substr = ''
+    ## capture the name excluding the 'rawMetric.' prefix
+    #regex = '^(.*)$'
+    ## use the captured metric name and suffix it with '.sum'
+    #format = '$1.sum'
+    #interval = 10
+    #wait = 15
+    ## drop the raw data, we do not need it anymore
+    #dropRaw = true
+
+    # [[route]]
+    # key = 'carbon-default'
+    # type = 'sendAllMatch'
+    # destinations = [
+    #   '127.0.0.1:1234 spool=true pickle=false'
+    # ]
+
+    [[route]]
+    prefix = ''
+    substr = ''
+    regex = ''
+    key = 'grafanaNet'
+    type = 'grafanaNet'
+    addr = "${GRAFANA_NET_ADDR}"
+    apikey = "${GRAFANA_NET_USER_ID}:${GRAFANA_NET_API_KEY}"
+    schemasFile = '/conf/storage-schemas.conf'
+  storage-schemas.conf: |
+    [default]
+    pattern = .*
+    retentions = 10s:1d
+kind: ConfigMap
+metadata:
+  name: carbon-relay-ng-config
+  namespace: mynamespace

--- a/examples/k8s/deployment.yaml
+++ b/examples/k8s/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    name: carbon-relay-ng
+  name: carbon-relay-ng
+  namespace: mynamespace
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: carbon-relay-ng
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        name: carbon-relay-ng
+    spec:
+      containers:
+      - env:
+        - name: INSTANCE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: GRAFANA_NET_ADDR
+          value: https://tsdb-1-<instance name>.hosted-metrics.grafana.net/metrics
+        - name: GRAFANA_NET_USER_ID
+          value: api_key
+        - name: GRAFANA_NET_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: api_key
+              name: crng-metrics-key
+        image: raintank/carbon-relay-ng:master
+        imagePullPolicy: Always
+        name: carbon-relay-ng
+        ports:
+        - containerPort: 2003
+          name: carbon
+        resources:
+          limits:
+            cpu: "4"
+            memory: 10Gi
+          requests:
+            cpu: "1"
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /conf
+          name: carbon-relay-ng-config
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: carbon-relay-ng-config
+        name: carbon-relay-ng-config

--- a/examples/k8s/secret.yaml
+++ b/examples/k8s/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  # the api_key must be base64 encoded
+  api_key: PGJhc2U2NCBhcGkga2V5Pg==
+kind: Secret
+metadata:
+  name: crng-metrics-key
+  namespace: mynamespace
+type: Opaque

--- a/examples/k8s/service.yaml
+++ b/examples/k8s/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: carbon-relay-ng
+  name: carbon-relay-ng
+  namespace: mynamespace
+spec:
+  ports:
+  - name: carbon-relay-ng-carbon
+    port: 2003
+    targetPort: 2003
+  selector:
+    name: carbon-relay-ng

--- a/ksonnet/lib/carbon-relay-ng/crng.libsonnet
+++ b/ksonnet/lib/carbon-relay-ng/crng.libsonnet
@@ -1,0 +1,68 @@
+{
+  _images+:: {
+    carbon_relay_ng: 'raintank/carbon-relay-ng:master'
+  },
+
+  _config+:: {
+    namespace: error 'must define namespace',
+    crng_api_key: error 'must provide b64 encoded api_key',
+    crng_route_host: error 'must provide a crng route host',
+    crng_user_id: error 'must provide a crng user id',
+    crng_replicas: 1,
+    crng_config: importstr 'files/carbon-relay-ng.ini',
+    storage_schemas: importstr 'files/storage-schemas.conf',
+  },
+
+  local configMap = $.core.v1.configMap,
+  carbon_relay_ng_config_map:
+    configMap.new('carbon-relay-ng-config') +
+    configMap.mixin.metadata.withNamespace($._config.namespace) +
+    configMap.withData(
+      {
+        'carbon-relay-ng.ini': $._config.crng_config,
+        'storage-schemas.conf': $._config.storage_schemas,
+      }
+    ),
+  
+  local secret = $.core.v1.secret,
+  carbon_relay_ng_secret:
+    secret.new(
+      'crng-metrics-key',
+      {
+        api_key: std.base64($._config.crng_api_key),
+      },
+      'Opaque'
+    ) +
+    secret.mixin.metadata.withNamespace($._config.namespace),
+
+  local container = $.core.v1.container,
+  carbon_relay_ng_container::
+    container
+    .new('carbon-relay-ng', $._images.carbon_relay_ng)
+    .withImagePullPolicy('Always') +
+    container.withPorts($.core.v1.containerPort.new('carbon', 2003)) +
+    container.withEnv([
+      container.envType.fromFieldPath('INSTANCE', 'metadata.name'),
+      container.envType.new('GRAFANA_NET_ADDR', $._config.crng_route_host),
+      container.envType.new('GRAFANA_NET_USER_ID', $._config.crng_user_id),
+      container.envType.fromSecretRef('GRAFANA_NET_API_KEY', 'crng-metrics-key', 'api_key'),
+    ]) +
+    $.util.resourcesLimits('4', '10Gi') +
+    $.util.resourcesRequests('1', '1Gi'),
+
+  local deployment = $.apps.v1beta1.deployment,
+  carbon_relay_ng_deployment:
+    deployment.new('carbon-relay-ng', $._config.crng_replicas, [$.carbon_relay_ng_container]) +
+    deployment.mixin.metadata.withNamespace($._config.namespace) +
+    deployment.mixin.metadata.withLabels({ name: 'carbon-relay-ng' }) +
+    deployment.mixin.spec.selector.withMatchLabels({ name: 'carbon-relay-ng' }) +
+    deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(30) +
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(1) +
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(0) +
+    $.util.configVolumeMount('carbon-relay-ng-config', '/conf'),
+
+  local service = $.core.v1.service,
+  carbon_relay_ng_service:
+    $.util.serviceFor($.carbon_relay_ng_deployment) +
+    service.mixin.metadata.withNamespace($._config.namespace)
+}

--- a/ksonnet/lib/carbon-relay-ng/files/carbon-relay-ng.ini
+++ b/ksonnet/lib/carbon-relay-ng/files/carbon-relay-ng.ini
@@ -1,0 +1,137 @@
+## Global settings ##
+
+# instance id's distinguish stats of multiple relays.
+# do not run multiple relays with the same instance id.
+# supported variables:
+#  ${HOST} : hostname
+instance = "${HOST}"
+
+## System ##
+# this setting can be used to override the default GOMAXPROCS logic
+# it is ignored if the GOMAXPROCS environment variable is set
+# max_procs = 2
+pid_file = "/tmp/carbon-relay-ng.pid"
+# directory for spool files
+spool_dir = "/tmp/carbon-relay-ng"
+
+## Logging ##
+# one of trace debug info warn error fatal panic
+# see docs/logging.md for level descriptions
+# note: if you used to use `notice`, you should now use `info`.
+log_level = "trace"
+
+## Admin ##
+admin_addr = "0.0.0.0:2004"
+http_addr = "0.0.0.0:8081"
+
+## Inputs ##
+### plaintext Carbon ###
+listen_addr = "0.0.0.0:2003"
+# close inbound plaintext connections if they've been idle for this long ("0s" to disable)
+plain_read_timeout = "2m"
+### Pickle Carbon ###
+pickle_addr = "0.0.0.0:2013"
+# close inbound pickle connections if they've been idle for this long ("0s" to disable)
+pickle_read_timeout = "2m"
+
+## Validation of inputs ##
+# Metric name validation strictness for legacy metrics. Valid values are:
+# strict - Block anything that can upset graphite: valid characters are [A-Za-z0-9_-.]; consecutive dots are not allowed
+# medium - Valid characters are ASCII; no embedded NULLs
+# none   - No validation is performed
+validation_level_legacy = "medium"
+# Metric validation for carbon2.0 (metrics2.0) metrics.
+# Metrics that contain = or _is_ are assumed carbon2.0.
+# Valid values are:
+# medium - checks for unit and mtype tag, presence of another tag, and constency (use = or _is_, not both)
+# none   - No validation is performed
+validation_level_m20 = "medium"
+
+# you can also validate that each series has increasing timestamps
+validate_order = false
+
+# How long to keep track of invalid metrics seen
+# Useful time units are "s", "m", "h"
+bad_metrics_max_age = "24h"
+
+# Aggregators
+# See https://github.com/grafana/carbon-relay-ng/blob/master/docs/config.md#Aggregators
+
+# Rewriters
+# See https://github.com/grafana/carbon-relay-ng/blob/master/docs/config.md#Rewriters
+
+# Routes
+# See https://github.com/grafana/carbon-relay-ng/blob/master/docs/config.md#Routes
+
+[init]
+# init commands (DEPRECATED)
+# see https://github.com/grafana/carbon-relay-ng/blob/master/docs/config.md#Imperatives
+cmds = [
+]
+
+## Instrumentation ##
+
+[instrumentation]
+# in addition to serving internal metrics via expvar, you can send them to graphite/carbon
+# IMPORTANT: setting this to "" will disable flushing, and metrics will pile up and lead to OOM
+# see https://github.com/grafana/carbon-relay-ng/issues/50
+# so for now you MUST send them somewhere. sorry.
+# (Also, the interval here must correspond to your setting in storage-schemas.conf if you use grafana hosted metrics)
+#graphite_addr = "localhost:2003"
+#graphite_interval = 10000  # in ms
+
+# we prefix every raw metric with the string 'rawMetric.' because further down in the
+# aggregators we want to be able to only ingest the raw metrics and not the outputs of
+# the aggregators
+#[[rewriter]]
+#old = '/^/'
+#new = 'rawMetric.'
+#not = ''
+#max = -1
+
+# ingest all metrics prefixed with 'rawMetric.' and generate averaged aggregates
+# which are suffixed with the string '.avg'
+#[[aggregation]]
+#function = 'avg'
+#prefix = ''
+#substr = ''
+## capture the name excluding the 'rawMetric.' prefix
+#regex = '^(.*)$'
+## use the captured metric name and suffix it with '.avg'
+#format = '$1.avg'
+#interval = 10
+#wait = 15
+## do not drop the raw data, as we still need it for the next aggregator
+#dropRaw = false
+#
+## ingest all metrics prefixed with 'rawMetric.' and generate summed aggregates
+## which are suffixed with the string '.sum'
+#[[aggregation]]
+#function = 'sum'
+#prefix = ''
+#substr = ''
+## capture the name excluding the 'rawMetric.' prefix
+#regex = '^(.*)$'
+## use the captured metric name and suffix it with '.sum'
+#format = '$1.sum'
+#interval = 10
+#wait = 15
+## drop the raw data, we do not need it anymore
+#dropRaw = true
+
+# [[route]]
+# key = 'carbon-default'
+# type = 'sendAllMatch'
+# destinations = [
+#   '127.0.0.1:1234 spool=true pickle=false'
+# ]
+
+[[route]]
+prefix = ''
+substr = ''
+regex = ''
+key = 'grafanaNet'
+type = 'grafanaNet'
+addr = "${GRAFANA_NET_ADDR}"
+apikey = "${GRAFANA_NET_USER_ID}:${GRAFANA_NET_API_KEY}"
+schemasFile = '/conf/storage-schemas.conf'

--- a/ksonnet/lib/carbon-relay-ng/files/storage-schemas.conf
+++ b/ksonnet/lib/carbon-relay-ng/files/storage-schemas.conf
@@ -1,0 +1,3 @@
+[default]
+pattern = .*
+retentions = 10s:1d

--- a/ksonnet/lib/carbon-relay-ng/jsonnetfile.json
+++ b/ksonnet/lib/carbon-relay-ng/jsonnetfile.json
@@ -1,0 +1,14 @@
+{
+    "dependencies": [
+        {
+            "name": "ksonnet-util",
+            "source": {
+                "git": {
+                    "remote": "https://github.com/grafana/jsonnet-libs",
+                    "subdir": "ksonnet-util"
+                }
+            },
+            "version": "master"
+        }
+    ]
+}


### PR DESCRIPTION
Document how to deploy carbon-relay-ng on Kubernetes.

This provides a ksonnet mixin to create all the necessary resource, plus documentation on how to use it.
Furthermore, for users who don't use ksonnet it also includes example `.yaml` files which may be used as a template.