### PR TITLE
use carbon-relay-ng config from examples

### DIFF
--- a/examples/k8s/configmap.yaml
+++ b/examples/k8s/configmap.yaml
@@ -1,8 +1,7 @@
 apiVersion: v1
 data:
-  carbon-relay-ng.ini: |
+  carbon-relay-ng.ini: |-
     ## Global settings ##
-
     # instance id's distinguish stats of multiple relays.
     # do not run multiple relays with the same instance id.
     # supported variables:
@@ -12,20 +11,16 @@ data:
     ## System ##
     # this setting can be used to override the default GOMAXPROCS logic
     # it is ignored if the GOMAXPROCS environment variable is set
-    # max_procs = 2
-    pid_file = "/tmp/carbon-relay-ng.pid"
+    max_procs = 2
+    pid_file = "carbon-relay-ng.pid"
     # directory for spool files
-    spool_dir = "/tmp/carbon-relay-ng"
+    spool_dir = "spool"
 
     ## Logging ##
     # one of trace debug info warn error fatal panic
     # see docs/logging.md for level descriptions
-    # note: if you used to use `notice`, you should now use `info`.
-    log_level = "trace"
-
-    ## Admin ##
-    admin_addr = "0.0.0.0:2004"
-    http_addr = "0.0.0.0:8081"
+    # note: if you used to use "notice", you should now use "info".
+    log_level = "info"
 
     ## Inputs ##
     ### plaintext Carbon ###
@@ -38,18 +33,6 @@ data:
     pickle_read_timeout = "2m"
 
     ## Validation of inputs ##
-    # Metric name validation strictness for legacy metrics. Valid values are:
-    # strict - Block anything that can upset graphite: valid characters are [A-Za-z0-9_-.]; consecutive dots are not allowed
-    # medium - Valid characters are ASCII; no embedded NULLs
-    # none   - No validation is performed
-    validation_level_legacy = "medium"
-    # Metric validation for carbon2.0 (metrics2.0) metrics.
-    # Metrics that contain = or _is_ are assumed carbon2.0.
-    # Valid values are:
-    # medium - checks for unit and mtype tag, presence of another tag, and constency (use = or _is_, not both)
-    # none   - No validation is performed
-    validation_level_m20 = "medium"
-
     # you can also validate that each series has increasing timestamps
     validate_order = false
 
@@ -57,87 +40,22 @@ data:
     # Useful time units are "s", "m", "h"
     bad_metrics_max_age = "24h"
 
-    # Aggregators
-    # See https://github.com/grafana/carbon-relay-ng/blob/master/docs/config.md#Aggregators
-
-    # Rewriters
-    # See https://github.com/grafana/carbon-relay-ng/blob/master/docs/config.md#Rewriters
-
-    # Routes
-    # See https://github.com/grafana/carbon-relay-ng/blob/master/docs/config.md#Routes
-
-    [init]
-    # init commands (DEPRECATED)
-    # see https://github.com/grafana/carbon-relay-ng/blob/master/docs/config.md#Imperatives
-    cmds = [
-    ]
-
-    ## Instrumentation ##
-
-    [instrumentation]
-    # in addition to serving internal metrics via expvar, you can send them to graphite/carbon
-    # IMPORTANT: setting this to "" will disable flushing, and metrics will pile up and lead to OOM
-    # see https://github.com/grafana/carbon-relay-ng/issues/50
-    # so for now you MUST send them somewhere. sorry.
-    # (Also, the interval here must correspond to your setting in storage-schemas.conf if you use grafana hosted metrics)
-    #graphite_addr = "localhost:2003"
-    #graphite_interval = 10000  # in ms
-
-    # we prefix every raw metric with the string 'rawMetric.' because further down in the
-    # aggregators we want to be able to only ingest the raw metrics and not the outputs of
-    # the aggregators
-    #[[rewriter]]
-    #old = '/^/'
-    #new = 'rawMetric.'
-    #not = ''
-    #max = -1
-
-    # ingest all metrics prefixed with 'rawMetric.' and generate averaged aggregates
-    # which are suffixed with the string '.avg'
-    #[[aggregation]]
-    #function = 'avg'
-    #prefix = ''
-    #substr = ''
-    ## capture the name excluding the 'rawMetric.' prefix
-    #regex = '^(.*)$'
-    ## use the captured metric name and suffix it with '.avg'
-    #format = '$1.avg'
-    #interval = 10
-    #wait = 15
-    ## do not drop the raw data, as we still need it for the next aggregator
-    #dropRaw = false
-    #
-    ## ingest all metrics prefixed with 'rawMetric.' and generate summed aggregates
-    ## which are suffixed with the string '.sum'
-    #[[aggregation]]
-    #function = 'sum'
-    #prefix = ''
-    #substr = ''
-    ## capture the name excluding the 'rawMetric.' prefix
-    #regex = '^(.*)$'
-    ## use the captured metric name and suffix it with '.sum'
-    #format = '$1.sum'
-    #interval = 10
-    #wait = 15
-    ## drop the raw data, we do not need it anymore
-    #dropRaw = true
-
-    # [[route]]
-    # key = 'carbon-default'
-    # type = 'sendAllMatch'
-    # destinations = [
-    #   '127.0.0.1:1234 spool=true pickle=false'
-    # ]
-
     [[route]]
-    prefix = ''
-    substr = ''
-    regex = ''
     key = 'grafanaNet'
     type = 'grafanaNet'
     addr = "${GRAFANA_NET_ADDR}"
     apikey = "${GRAFANA_NET_USER_ID}:${GRAFANA_NET_API_KEY}"
     schemasFile = '/conf/storage-schemas.conf'
+
+    ## Instrumentation ##
+    [instrumentation]
+    # in addition to serving internal metrics via expvar, you can send them to graphite/carbon
+    # IMPORTANT: setting this to "" will disable flushing, and metrics will pile up and lead to OOM
+    # see https://github.com/graphite-ng/carbon-relay-ng/issues/50
+    # so for now you MUST send them somewhere. sorry.
+    # (Also, the interval here must correspond to your setting in storage-schemas.conf if you use Grafana Cloud)
+    graphite_addr = "localhost:2003"
+    graphite_interval = 10000  # in ms
   storage-schemas.conf: |
     [default]
     pattern = .*

--- a/jsonnet/lib/carbon-relay-ng/files/carbon-relay-ng.ini
+++ b/jsonnet/lib/carbon-relay-ng/files/carbon-relay-ng.ini
@@ -1,5 +1,4 @@
 ## Global settings ##
-
 # instance id's distinguish stats of multiple relays.
 # do not run multiple relays with the same instance id.
 # supported variables:
@@ -9,20 +8,16 @@ instance = "${HOST}"
 ## System ##
 # this setting can be used to override the default GOMAXPROCS logic
 # it is ignored if the GOMAXPROCS environment variable is set
-# max_procs = 2
-pid_file = "/tmp/carbon-relay-ng.pid"
+max_procs = 2
+pid_file = "carbon-relay-ng.pid"
 # directory for spool files
-spool_dir = "/tmp/carbon-relay-ng"
+spool_dir = "spool"
 
 ## Logging ##
 # one of trace debug info warn error fatal panic
 # see docs/logging.md for level descriptions
-# note: if you used to use `notice`, you should now use `info`.
-log_level = "trace"
-
-## Admin ##
-admin_addr = "0.0.0.0:2004"
-http_addr = "0.0.0.0:8081"
+# note: if you used to use "notice", you should now use "info".
+log_level = "info"
 
 ## Inputs ##
 ### plaintext Carbon ###
@@ -35,18 +30,6 @@ pickle_addr = "0.0.0.0:2013"
 pickle_read_timeout = "2m"
 
 ## Validation of inputs ##
-# Metric name validation strictness for legacy metrics. Valid values are:
-# strict - Block anything that can upset graphite: valid characters are [A-Za-z0-9_-.]; consecutive dots are not allowed
-# medium - Valid characters are ASCII; no embedded NULLs
-# none   - No validation is performed
-validation_level_legacy = "medium"
-# Metric validation for carbon2.0 (metrics2.0) metrics.
-# Metrics that contain = or _is_ are assumed carbon2.0.
-# Valid values are:
-# medium - checks for unit and mtype tag, presence of another tag, and constency (use = or _is_, not both)
-# none   - No validation is performed
-validation_level_m20 = "medium"
-
 # you can also validate that each series has increasing timestamps
 validate_order = false
 
@@ -54,84 +37,19 @@ validate_order = false
 # Useful time units are "s", "m", "h"
 bad_metrics_max_age = "24h"
 
-# Aggregators
-# See https://github.com/grafana/carbon-relay-ng/blob/master/docs/config.md#Aggregators
-
-# Rewriters
-# See https://github.com/grafana/carbon-relay-ng/blob/master/docs/config.md#Rewriters
-
-# Routes
-# See https://github.com/grafana/carbon-relay-ng/blob/master/docs/config.md#Routes
-
-[init]
-# init commands (DEPRECATED)
-# see https://github.com/grafana/carbon-relay-ng/blob/master/docs/config.md#Imperatives
-cmds = [
-]
-
-## Instrumentation ##
-
-[instrumentation]
-# in addition to serving internal metrics via expvar, you can send them to graphite/carbon
-# IMPORTANT: setting this to "" will disable flushing, and metrics will pile up and lead to OOM
-# see https://github.com/grafana/carbon-relay-ng/issues/50
-# so for now you MUST send them somewhere. sorry.
-# (Also, the interval here must correspond to your setting in storage-schemas.conf if you use grafana hosted metrics)
-#graphite_addr = "localhost:2003"
-#graphite_interval = 10000  # in ms
-
-# we prefix every raw metric with the string 'rawMetric.' because further down in the
-# aggregators we want to be able to only ingest the raw metrics and not the outputs of
-# the aggregators
-#[[rewriter]]
-#old = '/^/'
-#new = 'rawMetric.'
-#not = ''
-#max = -1
-
-# ingest all metrics prefixed with 'rawMetric.' and generate averaged aggregates
-# which are suffixed with the string '.avg'
-#[[aggregation]]
-#function = 'avg'
-#prefix = ''
-#substr = ''
-## capture the name excluding the 'rawMetric.' prefix
-#regex = '^(.*)$'
-## use the captured metric name and suffix it with '.avg'
-#format = '$1.avg'
-#interval = 10
-#wait = 15
-## do not drop the raw data, as we still need it for the next aggregator
-#dropRaw = false
-#
-## ingest all metrics prefixed with 'rawMetric.' and generate summed aggregates
-## which are suffixed with the string '.sum'
-#[[aggregation]]
-#function = 'sum'
-#prefix = ''
-#substr = ''
-## capture the name excluding the 'rawMetric.' prefix
-#regex = '^(.*)$'
-## use the captured metric name and suffix it with '.sum'
-#format = '$1.sum'
-#interval = 10
-#wait = 15
-## drop the raw data, we do not need it anymore
-#dropRaw = true
-
-# [[route]]
-# key = 'carbon-default'
-# type = 'sendAllMatch'
-# destinations = [
-#   '127.0.0.1:1234 spool=true pickle=false'
-# ]
-
 [[route]]
-prefix = ''
-substr = ''
-regex = ''
 key = 'grafanaNet'
 type = 'grafanaNet'
 addr = "${GRAFANA_NET_ADDR}"
 apikey = "${GRAFANA_NET_USER_ID}:${GRAFANA_NET_API_KEY}"
 schemasFile = '/conf/storage-schemas.conf'
+
+## Instrumentation ##
+[instrumentation]
+# in addition to serving internal metrics via expvar, you can send them to graphite/carbon
+# IMPORTANT: setting this to "" will disable flushing, and metrics will pile up and lead to OOM
+# see https://github.com/graphite-ng/carbon-relay-ng/issues/50
+# so for now you MUST send them somewhere. sorry.
+# (Also, the interval here must correspond to your setting in storage-schemas.conf if you use Grafana Cloud)
+graphite_addr = "localhost:2003"
+graphite_interval = 10000  # in ms


### PR DESCRIPTION
This uses the `carbon-relay-ng.ini` config from `examples/carbon-relay-ng.ini`