### PR TITLE
switch docker references from raintank to grafana

### DIFF
--- a/docs/installation-building.md
+++ b/docs/installation-building.md
@@ -23,7 +23,7 @@ Executable Binaries for Linux, Mac, and Windows can be found on the [releases](h
 
 ## Docker images
 
-See [dockerhub](https://hub.docker.com/r/raintank/carbon-relay-ng/).
+See [dockerhub](https://hub.docker.com/r/grafana/carbon-relay-ng/).
 
 You can use these tags:
 

--- a/examples/k8s/deployment.yaml
+++ b/examples/k8s/deployment.yaml
@@ -36,7 +36,7 @@ spec:
             secretKeyRef:
               key: api_key
               name: crng-metrics-key
-        image: raintank/carbon-relay-ng:master
+        image: grafana/carbon-relay-ng:master
         imagePullPolicy: Always
         name: carbon-relay-ng
         ports:

--- a/jsonnet/lib/carbon-relay-ng/crng.libsonnet
+++ b/jsonnet/lib/carbon-relay-ng/crng.libsonnet
@@ -1,7 +1,7 @@
 local k = import 'ksonnet-util/kausal.libsonnet';
 {
   _images+:: {
-    carbon_relay_ng: 'raintank/carbon-relay-ng:master',
+    carbon_relay_ng: 'grafana/carbon-relay-ng:master',
   },
 
   _config+:: {


### PR DESCRIPTION
because we have been pushing to both for a while...
but we haven't pushed a release yet, so the "latest" tag
doesn't work yet. So this should only be merged right before
we publish the next stable release