### PR TITLE
instruct to include all binaries for release.

### DIFF
--- a/docs/installation-building.md
+++ b/docs/installation-building.md
@@ -78,4 +78,4 @@ When interesting changes have been merged to master, and they have had a chance 
 * trigger re-run of the CI pipeline to build packages with new version tag
 * wait for CircleCI to complete successfully
 * create release on GitHub. copy entry from CHANGELOG.md to GitHub release page
-* upload platform specific binaries from CircleCI artifacts to the release as well
+* upload platform specific (Linux, Mac and windows) binaries from CircleCI to the release as well


### PR DESCRIPTION
why?
* doesn't hurt to make it easier for people who want binaries
* the section "Binaries" above already claims we do this anyway

before merging this, make sure to update 0.13.0 release page