### PR TITLE
kafkamdm: make kafka version configurable

### DIFF
--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -105,6 +105,7 @@ type Route struct {
 	Topic         string // also used by Google PubSub
 	Codec         string // also used by Google PubSub
 	PartitionBy   string
+	KafkaVersion  string
 	TLSEnabled    bool
 	TLSSkipVerify bool
 	TLSClientCert string

--- a/docs/config.md
+++ b/docs/config.md
@@ -218,6 +218,7 @@ topic          |     Y     |  string     | N/A     |
 codec          |     Y     |  string     | N/A     | which compression to use. possible values: none, gzip, snappy
 partitionBy    |     Y     |  string     | N/A     | which fields to shard by. possible values are: byOrg, bySeries, bySeriesWithTags
 schemasFile    |     Y     |  string     | N/A     |
+kafkaVersion   |     N     |  string     | ""      | Kafka version in semver format. All brokers must be this version or newer. (fallback to oldest stable version 1.0.0)
 prefix         |     N     |  string     | ""      |
 notPrefix      |     N     |  string     | ""      |
 sub            |     N     |  string     | ""      |
@@ -248,6 +249,7 @@ brokers = ['kafka:9092']
 topic = 'mdm'
 codec = 'snappy'
 partitionBy = 'bySeriesWithTags'
+kafkaVersion = '2.0.0'
 schemasFile = 'conf/storage-schemas.conf'
 tlsEnabled = true
 tlsSkipVerify  = false

--- a/imperatives/imperatives.go
+++ b/imperatives/imperatives.go
@@ -68,6 +68,7 @@ const (
 	optSASLEnabled
 	optSASLUsername
 	optSASLPassword
+	optKafkaVersion
 	optUnspoolSleep
 	optPickle
 	optSpool
@@ -131,6 +132,7 @@ var tokens = []toki.Def{
 	{Token: optSASLEnabled, Pattern: "saslEnabled="},
 	{Token: optSASLUsername, Pattern: "saslUsername="},
 	{Token: optSASLPassword, Pattern: "saslPassword="},
+	{Token: optKafkaVersion, Pattern: "kafkaVersion="},
 	{Token: optUnspoolSleep, Pattern: "unspoolsleep="},
 	{Token: optPickle, Pattern: "pickle="},
 	{Token: optSpool, Pattern: "spool="},
@@ -696,6 +698,7 @@ func readAddRouteKafkaMdm(s *toki.Scanner, table Table) error {
 	var blocking = false
 	var tlsEnabled, tlsSkipVerify bool
 	var tlsClientCert, tlsClientKey string
+	var kafkaVersion string
 	var saslEnabled bool
 	var saslUsername, saslPassword string
 
@@ -806,12 +809,18 @@ func readAddRouteKafkaMdm(s *toki.Scanner, table Table) error {
 				return errFmtAddRouteKafkaMdm
 			}
 			saslPassword = string(t.Value)
+		case optKafkaVersion:
+			t = s.Next()
+			if t.Token != word {
+				return errFmtAddRouteKafkaMdm
+			}
+			kafkaVersion = string(t.Value)
 		default:
 			return fmt.Errorf("unexpected token %d %q", t.Token, t.Value)
 		}
 	}
 
-	route, err := route.NewKafkaMdm(key, matcher, topic, codec, schemasFile, partitionBy, brokers, bufSize, orgId, flushMaxNum, flushMaxWait, timeout, blocking, tlsEnabled, tlsSkipVerify, tlsClientCert, tlsClientKey, saslEnabled, saslUsername, saslPassword)
+	route, err := route.NewKafkaMdm(key, matcher, topic, codec, schemasFile, partitionBy, kafkaVersion, brokers, bufSize, orgId, flushMaxNum, flushMaxWait, timeout, blocking, tlsEnabled, tlsSkipVerify, tlsClientCert, tlsClientKey, saslEnabled, saslUsername, saslPassword)
 	if err != nil {
 		return err
 	}

--- a/table/table.go
+++ b/table/table.go
@@ -845,7 +845,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				orgId = routeConfig.OrgId
 			}
 
-			route, err := route.NewKafkaMdm(routeConfig.Key, matcher, routeConfig.Topic, routeConfig.Codec, routeConfig.SchemasFile, routeConfig.PartitionBy, routeConfig.Brokers, bufSize, orgId, flushMaxNum, flushMaxWait, timeout, routeConfig.Blocking, routeConfig.TLSEnabled, routeConfig.TLSSkipVerify, routeConfig.TLSClientCert, routeConfig.TLSClientKey, routeConfig.SASLEnabled, routeConfig.SASLUsername, routeConfig.SASLPassword)
+			route, err := route.NewKafkaMdm(routeConfig.Key, matcher, routeConfig.Topic, routeConfig.Codec, routeConfig.SchemasFile, routeConfig.PartitionBy, routeConfig.KafkaVersion, routeConfig.Brokers, bufSize, orgId, flushMaxNum, flushMaxWait, timeout, routeConfig.Blocking, routeConfig.TLSEnabled, routeConfig.TLSSkipVerify, routeConfig.TLSClientCert, routeConfig.TLSClientKey, routeConfig.SASLEnabled, routeConfig.SASLUsername, routeConfig.SASLPassword)
 			if err != nil {
 				log.Error(err.Error())
 				return fmt.Errorf("error adding route '%s'", routeConfig.Key)


### PR DESCRIPTION
This PR will fix #444 

This implementation will add kafkaVersion as option to the kafkamdm route. If no version got specified carbon-relay-ng will print a warning and use sarama.DefaultVersion.

This means that users can now specify the kafka version but if they don't do it carbon-relay-ng will act as in the current implementation.

ParseKafkaVersion will return the same default value on error as sarama.NewConfig() would: 
https://github.com/Shopify/sarama/blob/v1.23.0/utils.go#L196
https://github.com/Shopify/sarama/blob/v1.23.0/config.go#L439

We might discuss if the message regarding invalid version should be a warn or info.
