### PR TITLE
Fixed error check for process reporter

### DIFF
--- a/cmd/carbon-relay-ng/carbon-relay-ng.go
+++ b/cmd/carbon-relay-ng/carbon-relay-ng.go
@@ -184,10 +184,10 @@ func main() {
 		_, err = statsmt.NewProcessReporter()
 		if err != nil {
 			//ProcessReporter depends on /proc which doesn't exist on OSX/Windows
-			if strings.HasSuffix(err.Error(), "stat /proc: no such file or directory") {
-				log.Warn("stats: could not initialize process reporter because /proc does not exist")
-			} else {
+			if runtime.GOOS == "linux" {
 				log.Fatalf("stats: could not initialize process reporter: %v", err)
+			} else {
+				log.Warnf("stats: could not initialize process reporter: %v", err)
 			}
 		}
 		aggregator.NewAggregatorReporter()

--- a/cmd/carbon-relay-ng/carbon-relay-ng.go
+++ b/cmd/carbon-relay-ng/carbon-relay-ng.go
@@ -183,11 +183,11 @@ func main() {
 		statsmt.NewMemoryReporter()
 		_, err = statsmt.NewProcessReporter()
 		if err != nil {
-			//ProcessReporter depends on /proc which doesn't exist on OSX/Windows
-			if runtime.GOOS == "linux" {
-				log.Fatalf("stats: could not initialize process reporter: %v", err)
+			// ProcessReporter depends on /proc which does not exists/is not mounted by all platforms (Windows/OSX/FreeBSD)
+			if os.IsNotExist(err) {
+				log.Warnf("stats: could not initialize process - unsupported platform: %v", err)
 			} else {
-				log.Warnf("stats: could not initialize process reporter: %v", err)
+				log.Fatalf("stats: could not initialize process reporter: %v", err)
 			}
 		}
 		aggregator.NewAggregatorReporter()

--- a/statsmt/process_reporter.go
+++ b/statsmt/process_reporter.go
@@ -1,6 +1,7 @@
 package statsmt
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -15,7 +16,17 @@ type ProcessReporter struct {
 func NewProcessReporter() (*ProcessReporter, error) {
 	p := ProcessReporter{}
 	pid := os.Getpid()
-	var err error
+
+	// procfs.NewProc relies on /proc
+	// NewProc returns different errors on different platforms
+	// that make it difficult do isolate errors related to unavailable /proc/PID
+	// This check is compatible with all the platforms, and allow the caller
+	// to inspect the error with os.IsNotExist
+	_, err := os.Stat(fmt.Sprintf("/proc/%v", pid))
+	if err != nil {
+		return nil, err
+	}
+
 	p.proc, err = procfs.NewProc(pid)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
As per comment in the code, /proc is not available in Windows/OSX and Freebsd, but is available in Linux. 
In FreeBSD, the error message does not match the string checked in the if statement.

This relates to pr [391](https://github.com/grafana/carbon-relay-ng/pull/391/files)