### PR TITLE
GrafanaNet route: periodically post schemas

### DIFF
--- a/persister/whisper_schema.go
+++ b/persister/whisper_schema.go
@@ -40,6 +40,23 @@ func (s WhisperSchemas) Match(metric string) (Schema, bool) {
 	return Schema{}, false
 }
 
+// String() returns the string representation of the whisper schemas.
+// It is equivalent, though not identical to the original schemas that were parsed:
+// * priorities are derivatives of user input (and include position information), or explicitly 0 if unset in input
+// * entries are ordered based on priority
+// * the retentions string is provided exactly as the input
+// * no comments or extraneous whitespace is omitted
+func (s WhisperSchemas) String() string {
+	var buf strings.Builder
+	for _, schema := range s {
+		buf.WriteString(fmt.Sprintf("[%s]\n", schema.Name))
+		buf.WriteString(fmt.Sprintf("pattern = %s\n", schema.Pattern.String()))
+		buf.WriteString(fmt.Sprintf("retentions = %s\n", schema.RetentionStr))
+		buf.WriteString(fmt.Sprintf("priority = %d\n", schema.Priority))
+	}
+	return buf.String()
+}
+
 // ParseRetentionDefs parses retention definitions into a Retentions structure
 func ParseRetentionDefs(retentionDefs string) (whisper.Retentions, error) {
 	retentions := make(whisper.Retentions, 0)

--- a/persister/whisper_schema_test.go
+++ b/persister/whisper_schema_test.go
@@ -273,3 +273,44 @@ retentions = 60s:90d
 priority =
 `, nil, "Empty priority")
 }
+
+// TestSchemasString tests that routes.String() matches what we expect
+func TestSchemasString(t *testing.T) {
+	input := `# This is a wild comment
+[first]
+pattern = ^carbon\.
+retentions = 600s:90d,5m:365y
+   [fancy-patt-with-legacy-retentions]
+   pattern = ^patt2.*$
+retentions = 10:10
+priority = 6
+
+# another comment
+
+[hello]
+pattern = .*
+retentions = 10m:90d,10m:365y
+priority = 1`
+
+	exp := `[fancy-patt-with-legacy-retentions]
+pattern = ^patt2.*$
+retentions = 10:10
+priority = 25769803775
+[hello]
+pattern = .*
+retentions = 10m:90d,10m:365y
+priority = 4294967294
+[first]
+pattern = ^carbon\.
+retentions = 600s:90d,5m:365y
+priority = 0
+`
+	schemas, err := parseSchemas(t, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := schemas.String()
+	if exp != got {
+		t.Fatalf("expected %q - got %q", exp, got)
+	}
+}


### PR DESCRIPTION
On the grafana cloud side, we want to know the schemas that get applied
to metrics.  So we periodically post the "parsed" version of it to /metrics/schemas
which makes sure to exclude things like comments.

with an unpatched gw, we get 404 back and we handle it gracefully, retrying next time.
with a patched gw that reads the body and returns 200, it can see the schemas as expected