### PR TITLE
improve error messages, especially for storage-aggregation.conf

### DIFF
--- a/cfg/table.go
+++ b/cfg/table.go
@@ -207,6 +207,7 @@ func InitRoutes(table table.Interface, config Config, meta toml.MetaData) error 
 			cfg, err := route.NewGrafanaNetConfig(routeConfig.Addr, routeConfig.ApiKey, routeConfig.SchemasFile, routeConfig.AggregationFile)
 			if err != nil {
 				log.Error(err.Error())
+				log.Info("grafanaNet route configuration details: https://github.com/grafana/carbon-relay-ng/blob/master/docs/config.md#grafananet-route")
 				return fmt.Errorf("error adding route '%s'", routeConfig.Key)
 			}
 

--- a/route/grafananet.go
+++ b/route/grafananet.go
@@ -58,14 +58,22 @@ func NewGrafanaNetConfig(addr, apiKey, schemasFile, aggregationFile string) (Gra
 
 	u, err := url.Parse(addr)
 	if err != nil || !u.IsAbs() || u.Host == "" { // apparently "http://" is a valid absolute URL (with empty host), but we don't want that
-		return GrafanaNetConfig{}, fmt.Errorf("NewGrafanaNetConfig: invalid addr %q. need an absolute http[s] url", addr)
+		return GrafanaNetConfig{}, fmt.Errorf("NewGrafanaNetConfig: invalid value for 'addr': %q. need an absolute http[s] url", addr)
 	}
 	if !strings.HasSuffix(u.Path, "/metrics") && !strings.HasSuffix(u.Path, "/metrics/") {
-		return GrafanaNetConfig{}, fmt.Errorf("NewGrafanaNetConfig: invalid addr %q. needs to be a /metrics endpoint", addr)
+		return GrafanaNetConfig{}, fmt.Errorf("NewGrafanaNetConfig: invalid value for 'addr': %q. needs to be a /metrics endpoint", addr)
 	}
 
 	if apiKey == "" {
-		return GrafanaNetConfig{}, errors.New("NewGrafanaNetConfig: invalid apiKey")
+		return GrafanaNetConfig{}, errors.New("NewGrafanaNetConfig: invalid value for 'apiKey'. value must be set to non-empty string")
+	}
+
+	if schemasFile == "" {
+		return GrafanaNetConfig{}, errors.New("NewGrafanaNetConfig: invalid value for 'schemasFile'. value must be set to the path to your storage-schemas.conf file")
+	}
+
+	if aggregationFile == "" {
+		return GrafanaNetConfig{}, errors.New("NewGrafanaNetConfig: invalid value for 'aggregationFile'. value must be set to the path to your storage-aggregation.conf file")
 	}
 
 	_, err = getSchemas(schemasFile)


### PR DESCRIPTION
fix #469 
```
BEFORE:
2021-07-01 22:49:45.813 [ERROR] NewGrafanaNetConfig: could not read aggregationFile "": read .: is a directory
2021-07-01 22:49:45.815 [ERROR] error adding route 'grafanaNet'

AFTER:

2021-07-07 15:01:52.567 [ERROR] NewGrafanaNetConfig: invalid value for 'aggregationFile'. value must be set to the path to your storage-aggregation.conf file
2021-07-07 15:01:52.567 [INFO] grafanaNet route configuration details: https://github.com/grafana/carbon-relay-ng/blob/master/docs/config.md#grafananet-route
2021-07-07 15:01:52.567 [ERROR] error adding route 'grafanaNet'
```