### PR TITLE
Build Linux packages for multiple architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 RUN apk --update add --no-cache ca-certificates
-ADD carbon-relay-ng /bin/
+ADD carbon-relay-ng-linux-amd64 /bin/carbon-relay-ng
 VOLUME /conf
 ADD examples/carbon-relay-ng.ini /conf/carbon-relay-ng.ini
 RUN mkdir /var/spool/carbon-relay-ng

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 VERSION=$(shell git describe --tags --always | sed 's/^v//')
 export GO111MODULE := on
 
+# Run e.g. "make LINUX_PACKAGE_GOARCH=arm64" to produce ARM64 packages
+LINUX_PACKAGE_GOARCH ?= amd64
+
 build:
 	cd ui/web && go-bindata -pkg web admin_http_assets/...
 	find . -name '*.go' | grep -v '^\.\/vendor' | xargs gofmt -w -s
@@ -20,18 +23,18 @@ carbon-relay-ng-darwin:
 	find . -name '*.go' | grep -v '^\.\/vendor' | xargs gofmt -w -s
 	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-X main.Version=$(VERSION)" -o carbon-relay-ng-darwin ./cmd/carbon-relay-ng
 
-build-linux: carbon-relay-ng
+build-linux: carbon-relay-ng-linux-$(LINUX_PACKAGE_GOARCH)
 
 build-bsd:
 	cd ui/web && go-bindata -pkg web admin_http_assets/...
 	find . -name '*.go' | grep -v '^\.\/vendor' | xargs gofmt -w -s
 	GOOS=freebsd GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-X main.Version=$(VERSION)" -o carbon-relay-ng-bsd ./cmd/carbon-relay-ng
 
-carbon-relay-ng:
+carbon-relay-ng-linux-%:
 	cd ui/web && go-bindata -pkg web admin_http_assets/...
 	find . -name '*.go' | grep -v '^\.\/vendor' | xargs gofmt -w -s
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-X main.Version=$(VERSION)" ./cmd/carbon-relay-ng
-	cp carbon-relay-ng carbon-relay-ng-linux
+	GOOS=linux GOARCH=$* CGO_ENABLED=0 go build -ldflags "-X main.Version=$(VERSION)" -o $@ ./cmd/carbon-relay-ng
+	cp $@ carbon-relay-ng-linux
 
 test:
 	go test -v -race ./...
@@ -44,7 +47,7 @@ all:
 deb: build-linux
 	mkdir -p build/deb-systemd
 	install -d debian/usr/bin debian/usr/share/man/man1 debian/etc/carbon-relay-ng debian/lib/systemd/system debian/var/run/carbon-relay-ng debian/usr/lib/tmpfiles.d
-	install carbon-relay-ng debian/usr/bin
+	install carbon-relay-ng-linux-$(LINUX_PACKAGE_GOARCH) debian/usr/bin/carbon-relay-ng
 	install -m 0644 examples/carbon-relay-ng.ini debian/etc/carbon-relay-ng/carbon-relay-ng.conf
 	install -m 0644 examples/carbon-relay-ng-tmpfiles.conf debian/usr/lib/tmpfiles.d/carbon-relay-ng.conf
 	install -m 0644 examples/carbon-relay-ng.service debian/lib/systemd/system
@@ -55,7 +58,7 @@ deb: build-linux
 		-t deb \
 		-n carbon-relay-ng \
 		-v $(VERSION)-1 \
-		-a native \
+		-a $(LINUX_PACKAGE_GOARCH) \
 		--config-files etc/carbon-relay-ng/carbon-relay-ng.conf \
 		-p build/deb-systemd/carbon-relay-ng-VERSION_ARCH.deb \
 		-m "Dieter Plaetinck <dieter@grafana.com>" \
@@ -67,9 +70,9 @@ deb: build-linux
 	rm -rf debian
 
 deb-upstart: build-linux
-	mkdir build/deb-upstart
+	mkdir -p build/deb-upstart
 	install -d debian/usr/bin debian/usr/share/man/man1 debian/etc/carbon-relay-ng
-	install carbon-relay-ng debian/usr/bin
+	install carbon-relay-ng-linux-$(LINUX_PACKAGE_GOARCH) debian/usr/bin/carbon-relay-ng
 	install -m 0644 examples/carbon-relay-ng.ini debian/etc/carbon-relay-ng/carbon-relay-ng.conf
 	install -m 0644 man/man1/carbon-relay-ng.1 debian/usr/share/man/man1
 	gzip debian/usr/share/man/man1/carbon-relay-ng.1
@@ -78,7 +81,7 @@ deb-upstart: build-linux
 		-t deb \
 		-n carbon-relay-ng \
 		-v $(VERSION)-1 \
-		-a native \
+		-a $(LINUX_PACKAGE_GOARCH) \
 		--config-files etc/carbon-relay-ng/carbon-relay-ng.conf \
 		-p build/deb-upstart/carbon-relay-ng-VERSION_ARCH.deb \
 		--deb-upstart examples/carbon-relay-ng.upstart \
@@ -92,7 +95,7 @@ deb-upstart: build-linux
 rpm: build-linux
 	mkdir -p build/centos-7
 	install -d redhat/usr/bin redhat/usr/share/man/man1 redhat/etc/carbon-relay-ng redhat/lib/systemd/system redhat/var/run/carbon-relay-ng redhat/etc/tmpfiles.d
-	install carbon-relay-ng redhat/usr/bin
+	install carbon-relay-ng-linux-$(LINUX_PACKAGE_GOARCH) redhat/usr/bin/carbon-relay-ng
 	install -m 0644 man/man1/carbon-relay-ng.1 redhat/usr/share/man/man1
 	install -m 0644 examples/carbon-relay-ng.ini redhat/etc/carbon-relay-ng/carbon-relay-ng.conf
 	install -m 0644 examples/carbon-relay-ng-tmpfiles.conf redhat/etc/tmpfiles.d/carbon-relay-ng.conf
@@ -104,7 +107,7 @@ rpm: build-linux
 		-n carbon-relay-ng \
 		-v $(VERSION) \
 		--epoch 1 \
-		-a native \
+		-a $(LINUX_PACKAGE_GOARCH) \
 		--config-files etc/carbon-relay-ng/carbon-relay-ng.conf \
 		-p build/centos-7/carbon-relay-ng-VERSION.el7.ARCH.rpm \
 		-m "Dieter Plaetinck <dieter@grafana.com>" \
@@ -116,9 +119,9 @@ rpm: build-linux
 	rm -rf redhat
 
 rpm-centos6: build-linux
-	mkdir build/centos-6
+	mkdir -p build/centos-6
 	install -d redhat/usr/bin redhat/usr/share/man/man1 redhat/etc/carbon-relay-ng redhat/etc/init redhat/etc/init.d
-	install carbon-relay-ng redhat/usr/bin
+	install carbon-relay-ng-linux-$(LINUX_PACKAGE_GOARCH) redhat/usr/bin/carbon-relay-ng
 	install -m 0644 man/man1/carbon-relay-ng.1 redhat/usr/share/man/man1
 	install -m 0644 examples/carbon-relay-ng.ini redhat/etc/carbon-relay-ng/carbon-relay-ng.conf
 	install -m 0644 examples/carbon-relay-ng.upstart-0.6.5 redhat/etc/init/carbon-relay-ng.conf
@@ -130,7 +133,7 @@ rpm-centos6: build-linux
 		-n carbon-relay-ng \
 		-v $(VERSION) \
 		--epoch 1 \
-		-a native \
+		-a $(LINUX_PACKAGE_GOARCH) \
 		--config-files etc/carbon-relay-ng/carbon-relay-ng.conf \
 		-p build/centos-6/carbon-relay-ng-VERSION.el6.ARCH.rpm \
 		-m "Dieter Plaetinck <dieter@grafana.com>" \
@@ -140,7 +143,13 @@ rpm-centos6: build-linux
 		-C redhat .
 	rm -rf redhat
 
-packages: deb deb-upstart rpm rpm-centos6
+packages: packages-amd64 packages-arm64
+
+packages-amd64:
+	$(MAKE) LINUX_PACKAGE_GOARCH=amd64 deb deb-upstart rpm rpm-centos6
+
+packages-arm64:
+	$(MAKE) LINUX_PACKAGE_GOARCH=arm64 deb deb-upstart rpm rpm-centos6
 
 gh-pages: man
 	mkdir -p gh-pages
@@ -168,4 +177,4 @@ run-docker:
 clean:
 	rm -f carbon-relay-ng carbon-relay-ng.exe
 
-.PHONY: all deb gh-pages install man test build clean build-linux
+.PHONY: all deb gh-pages install man test build clean build-linux packages packages-amd64 packages-arm64


### PR DESCRIPTION
Currently, when building a Linux package on e.g. an ARM64 machine, the
package produced will be marked as an ARM64 package (because of the
"-a native" flag passed to fpm), but will contain an AMD64
executable (because the build-linux target sets GOARCH
unconditionally).

With this change, the desired architecture can be changed by setting
the LINUX_PACKAGE_GOARCH variable, so that the package will always
match the binary it contains. Also, the "packages" target builds
packages for both AMD64 and ARM64.