### PR TITLE
Update Jsonnet lib to work with latest Tanka version

### DIFF
--- a/docs/deploying-on-k8s.md
+++ b/docs/deploying-on-k8s.md
@@ -36,8 +36,8 @@ local crng = import 'carbon-relay-ng/crng.libsonnet';
   crng: crng {
     _config+:: {
       namespace: 'mynamespace',
-      crng_route_host: 'https://tsdb-1-<instance name>.hosted-metrics.grafana.net/metrics',
-      crng_user_id: 'api_key',
+      crng_route_host: '<graphite endpoint>/metrics',
+      crng_user_id: '<user id>',
       crng_api_key: '<base64 api key>',
     },
     _images+:: {

--- a/jsonnet/lib/carbon-relay-ng/crng.libsonnet
+++ b/jsonnet/lib/carbon-relay-ng/crng.libsonnet
@@ -45,8 +45,8 @@ local k = import 'ksonnet-util/kausal.libsonnet';
   local container = k.core.v1.container,
   carbon_relay_ng_container::
     container
-    .new('carbon-relay-ng', $._images.carbon_relay_ng)
-    .withImagePullPolicy('Always') +
+    .new('carbon-relay-ng', $._images.carbon_relay_ng) +
+    container.withImagePullPolicy('Always') +
     container.withPorts(k.core.v1.containerPort.new('carbon', 2003)) +
     container.withEnv([
       container.envType.fromFieldPath('INSTANCE', 'metadata.name'),
@@ -57,7 +57,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     k.util.resourcesLimits('4', '10Gi') +
     k.util.resourcesRequests('1', '1Gi'),
 
-  local deployment = k.apps.v1beta1.deployment,
+  local deployment = k.apps.v1.deployment,
   carbon_relay_ng_deployment:
     deployment.new('carbon-relay-ng', $._config.crng_replicas, [$.carbon_relay_ng_container]) +
     deployment.mixin.metadata.withNamespace($._config.namespace) +


### PR DESCRIPTION
The default k8s library used by Tanka was changed in https://github.com/grafana/tanka/pull/563. This meant the [k8s instructions](https://github.com/grafana/carbon-relay-ng/blob/master/docs/deploying-on-k8s.md) didn't work with the latest version of Tanka (v0.20); I was seeing an error like:
```
$ tk show environments/default/
Error: evaluating jsonnet: RUNTIME ERROR: Attempt to use super when there is no super class.
        /.../crng-tanka-check/vendor/github.com/jsonnet-libs/k8s-libsonnet/1.20/_custom/apps.libsonnet:35:7-12 function <anonymous>
        /.../crng-tanka-check/vendor/ksonnet-util/grafana.libsonnet:45:9-57    function <anonymous>
        /.../crng-tanka-check/vendor/carbon-relay-ng/crng.libsonnet:62:5-94    object <anonymous>
        Field "carbon_relay_ng_deployment"
        Field "crng"
        During manifestation
```

This PR updates the carbon-relay-ng jsonnet lib so it'll work with the updated k8s library, and also makes a small update to the k8s doc. 

# Testing
Followed the k8s instructions to set up the Tanka environment, ran `tk show environments/default`, which worked after I'd made changes to the jsonnet library.