### PR TITLE
Fix build instructions on latest go versions. 

### DIFF
--- a/docs/installation-building.md
+++ b/docs/installation-building.md
@@ -45,6 +45,7 @@ These commands will install the binary as `$GOPATH/bin/carbon-relay-ng`
     # e.g. to check out a specific version instead of master:
     # git checkout v1.1
     go get github.com/shuLhan/go-bindata/cmd/go-bindata
+    go install github.com/shuLhan/go-bindata/cmd/go-bindata
     make
 
 

--- a/docs/installation-building.md
+++ b/docs/installation-building.md
@@ -44,7 +44,6 @@ These commands will install the binary as `$GOPATH/bin/carbon-relay-ng`
     cd carbon-relay-ng
     # e.g. to check out a specific version instead of master:
     # git checkout v1.1
-    go get github.com/shuLhan/go-bindata/cmd/go-bindata
     go install github.com/shuLhan/go-bindata/cmd/go-bindata
     make
 


### PR DESCRIPTION
Using go get for installation is deprecated.  Advise to run go install for this.