### PR TITLE
Update CI to use newer cimg images and go version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   test:
     working_directory: /go/src/github.com/grafana/carbon-relay-ng
     docker:
-      - image: circleci/golang:1.17.3
+      - image: circleci/golang:1.18
     steps:
       - checkout
       - run: make test
@@ -11,7 +11,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/grafana/carbon-relay-ng
     docker:
-      - image: circleci/golang:1.17.3
+      - image: circleci/golang:1.18
     steps:
       - checkout
       - run: go get github.com/shuLhan/go-bindata/cmd/go-bindata

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,20 @@
 version: 2
 jobs:
   test:
-    working_directory: /go/src/github.com/grafana/carbon-relay-ng
+    working_directory: /home/circleci/go/src/github.com/grafana/carbon-relay-ng
     docker:
-      - image: circleci/golang:1.18
+      - image: cimg/go:1.18
     steps:
       - checkout
       - run: make test
 
   build:
-    working_directory: /go/src/github.com/grafana/carbon-relay-ng
+    working_directory: /home/circleci/go/src/github.com/grafana/carbon-relay-ng
     docker:
-      - image: circleci/golang:1.18
+      - image: cimg/go:1.18
     steps:
       - checkout
-      - run: go get github.com/shuLhan/go-bindata/cmd/go-bindata
+      - run: go install github.com/go-bindata/go-bindata/...@latest
       - run: make build-linux # note, this runs go-bindata again
       # ideally we'd make sure that if go-bindata generated new content, we fail.
       # because devs should have run go-bindata and checked in changes already.
@@ -35,8 +35,9 @@ jobs:
 
   package:
     docker:
-      - image: circleci/ruby:2.5
+      - image: cimg/ruby:2.5
     steps:
+      - run: sudo apt-get update
       - run: sudo apt-get install rpm
       - checkout
       - attach_workspace:
@@ -54,7 +55,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/ruby:2.3
+      - image: cimg/ruby:2.5
     steps:
       - setup_remote_docker
       - attach_workspace:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,31 @@
 test_spool
 spool/*.dat
 *~
+
+# Default ignore
+.vscode/*
+.uptodate
+.published
+.pkg
+.idea
+.cache
+*.output
+.drone/secrets.yml
+
+# Project specific secrets
+**/*.jwt
+app
+
+# Remove built binaries
+dist
+
+# Tag file used in drone and local env
+.tag
+.tags
+
+# Ignore vendor
+vendor
+
+# Ignore generated test coverage files
+cover.out
+cover.out.tmp

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/Dieterbe/go-metrics v0.0.0-20181015090856-87383909479d
 	github.com/Dieterbe/topic v0.0.0-20141209014555-1850ffda9965
 	github.com/Shopify/sarama v1.23.0
-	github.com/alyu/configparser v0.0.0-20191103060215-744e9a66e7bc // indirect
 	github.com/aws/aws-sdk-go v1.15.54
 	github.com/bmizerany/assert v0.0.0-20120716205630-e17e99893cb6
 	github.com/cespare/xxhash v0.0.0-00010101000000-000000000000 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/carbon-relay-ng
 
-go 1.13
+go 1.18
 
 require (
 	cloud.google.com/go v0.18.1-0.20180119164648-b1067c1d21b5
@@ -11,45 +11,68 @@ require (
 	github.com/Shopify/sarama v1.23.0
 	github.com/aws/aws-sdk-go v1.15.54
 	github.com/bmizerany/assert v0.0.0-20120716205630-e17e99893cb6
-	github.com/cespare/xxhash v0.0.0-00010101000000-000000000000 // indirect
-	github.com/dgryski/go-jump v0.0.0-20170409065014-e1f439676b57 // indirect
 	github.com/dgryski/go-linlog v0.0.0-20180207191225-edcf2dfd90ff
 	github.com/elazarl/go-bindata-assetfs v0.0.0-20151224045452-57eb5e1fc594
-	github.com/go-ini/ini v1.38.3 // indirect
-	github.com/golang/glog v0.0.0-20210429001901-424d2337a529 // indirect
-	github.com/golang/protobuf v0.0.0-20171113180720-1e59b77b52bf // indirect
 	github.com/golang/snappy v0.0.1
 	github.com/google/go-cmp v0.5.5
-	github.com/googleapis/gax-go v2.0.0+incompatible // indirect
-	github.com/gorilla/context v0.0.0-20141217160251-215affda49ad // indirect
 	github.com/gorilla/handlers v1.4.0
 	github.com/gorilla/mux v0.0.0-20140624184626-14cafe285133
 	github.com/grafana/configparser v0.0.0-20210707122942-2593eb86a3ee
 	github.com/grafana/metrictank v1.0.1-0.20210114150051-52835b9a8775
 	github.com/jpillora/backoff v0.0.0-20160414055204-0496a6c14df0
 	github.com/kisielk/og-rek v0.0.0-20170405223746-ec792bc6e6aa
-	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
-	github.com/kr/pretty v0.0.0-20160325215624-add1dbc86daf // indirect
-	github.com/kr/text v0.0.0-20150905224508-bb797dc4fb83 // indirect
 	github.com/metrics20/go-metrics20 v0.0.0-20180821133656-717ed3a27bf9
-	github.com/pelletier/go-toml v1.9.1 // indirect
-	github.com/philhofer/fwd v0.0.0-20151120024002-92647f2bd94a // indirect
 	github.com/prometheus/procfs v0.0.0-20190425082905-87a4384529e0
 	github.com/sirupsen/logrus v1.1.2-0.20181020050904-08e90462da34
-	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/streadway/amqp v0.0.0-20170521212453-dfe15e360485
 	github.com/stretchr/testify v1.3.0
 	github.com/taylorchu/toki v0.0.0-20141019163204-20e86122596c
-	github.com/tinylib/msgp v1.1.0 // indirect
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c
+)
+
+require (
+	github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798 // indirect
+	github.com/cespare/xxhash v0.0.0-00010101000000-000000000000 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgryski/go-jump v0.0.0-20170409065014-e1f439676b57 // indirect
+	github.com/eapache/go-resiliency v1.1.0 // indirect
+	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 // indirect
+	github.com/eapache/queue v1.1.0 // indirect
+	github.com/go-ini/ini v1.38.3 // indirect
+	github.com/golang/glog v0.0.0-20210429001901-424d2337a529 // indirect
+	github.com/golang/protobuf v0.0.0-20171113180720-1e59b77b52bf // indirect
+	github.com/googleapis/gax-go v2.0.0+incompatible // indirect
+	github.com/gorilla/context v0.0.0-20141217160251-215affda49ad // indirect
+	github.com/hashicorp/go-uuid v1.0.1 // indirect
+	github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03 // indirect
+	github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/kr/pretty v0.0.0-20160325215624-add1dbc86daf // indirect
+	github.com/kr/text v0.0.0-20150905224508-bb797dc4fb83 // indirect
+	github.com/pelletier/go-toml v1.9.1 // indirect
+	github.com/philhofer/fwd v0.0.0-20151120024002-92647f2bd94a // indirect
+	github.com/pierrec/lz4 v0.0.0-20190327172049-315a67e90e41 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a // indirect
+	github.com/smartystreets/goconvey v1.6.4 // indirect
+	github.com/tinylib/msgp v1.1.0 // indirect
+	github.com/xdg/stringprep v1.0.0 // indirect
+	golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5 // indirect
+	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 // indirect
 	golang.org/x/oauth2 v0.0.0-20180118004544-b28fcf2b08a1 // indirect
+	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 // indirect
+	golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e // indirect
 	golang.org/x/text v0.3.1-0.20171227012246-e19ae1496984 // indirect
 	google.golang.org/api v0.0.0-20180122000316-bc96e9251952 // indirect
 	google.golang.org/appengine v1.0.1-0.20170921170648-24e4144ec923 // indirect
 	google.golang.org/genproto v0.0.0-20171212231943-a8101f21cf98 // indirect
 	google.golang.org/grpc v1.2.1-0.20180119173759-b71aced4a2a1 // indirect
 	gopkg.in/ini.v1 v1.62.0 // indirect
+	gopkg.in/jcmturner/aescts.v1 v1.0.1 // indirect
+	gopkg.in/jcmturner/dnsutils.v1 v1.0.1 // indirect
 	gopkg.in/jcmturner/goidentity.v3 v3.0.0 // indirect
+	gopkg.in/jcmturner/gokrb5.v7 v7.2.3 // indirect
+	gopkg.in/jcmturner/rpc.v1 v1.1.0 // indirect
 )
 
 replace github.com/cespare/xxhash => github.com/cespare/xxhash/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,6 @@ github.com/Shopify/sarama v1.23.0 h1:slvlbm7bxyp7sKQbUwha5BQdZTqurhRoI+zbKorVigQ
 github.com/Shopify/sarama v1.23.0/go.mod h1:XLH1GYJnLVE0XCr6KdJGVJRTwY30moWNJ4sERjXX6fs=
 github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
-github.com/alyu/configparser v0.0.0-20191103060215-744e9a66e7bc h1:eN2FUvn4J1A31pICABioDYukoh1Tmlei6L3ImZUin/I=
-github.com/alyu/configparser v0.0.0-20191103060215-744e9a66e7bc/go.mod h1:BYq/NZTroWuzkvsTPJgRBqSHGxKMHCz06gtlfY/W5RU=
 github.com/aws/aws-sdk-go v1.15.54 h1:yNFryYgHYlEuNnMM74EZgAaOM2BsJvu77/ev9I9GHlU=
 github.com/aws/aws-sdk-go v1.15.54/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/bmizerany/assert v0.0.0-20120716205630-e17e99893cb6 h1:tqaG4PIbPslIfl+dhNXWUXRTgPI4Dpx7LaDQ6fS9mGM=
@@ -58,8 +56,6 @@ github.com/gorilla/handlers v1.4.0 h1:XulKRWSQK5uChr4pEgSE4Tc/OcmnU9GJuSwdog/tZs
 github.com/gorilla/handlers v1.4.0/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v0.0.0-20140624184626-14cafe285133 h1:ukbzVQxXffKnAteyOe2SD8pYokHCMYrLVygg6x1tCC0=
 github.com/gorilla/mux v0.0.0-20140624184626-14cafe285133/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/grafana/configparser v0.0.0-20210622142741-3e3967fd8d20 h1:vU/muwCTymcNiJZvuYzPtebHNkDPH8FF42QWBGMO3ms=
-github.com/grafana/configparser v0.0.0-20210622142741-3e3967fd8d20/go.mod h1:5kq854/YXuu4gJm0A2hON7r5IeAKTpap20ARcCZSugw=
 github.com/grafana/configparser v0.0.0-20210707122942-2593eb86a3ee h1:5j5kbjPdpun9I6taPXXvQnjUYaHxHg4Akgrh9JGB+4k=
 github.com/grafana/configparser v0.0.0-20210707122942-2593eb86a3ee/go.mod h1:5kq854/YXuu4gJm0A2hON7r5IeAKTpap20ARcCZSugw=
 github.com/grafana/metrictank v1.0.1-0.20210114150051-52835b9a8775 h1:5DryQe90TlOk9FiaS2fAShAQAkzy4OlSs0DS1LQU9rI=


### PR DESCRIPTION
This PR does two things:
- Update circleci images to use the new `cimg/go` and `cimg/ruby`  images instead of the deprecated `circleci/...` ones.
- Updates go mod to make carbon-relay-ng a go 1.18 project.