### PR TITLE
Retain Grafana Cloud/GEM schema fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# unreleased 
+* retain Grafana Cloud/GEM fields when parsing storage-schemas.conf #502
+
 # v1.2.1: patch maintenance release. December 22, 2022
 
 * build using go 1.18 #497


### PR DESCRIPTION
For https://github.com/grafana/carbon-relay-ng/issues/501

Grafana Cloud and Grafana Enterprise Metrics adds two additional fields to the Graphite storage-schemas.conf: `intervals` and `relativeToQuery`. Documentation for these two fields: https://grafana.com/docs/enterprise-metrics/latest/graphite/schemas/#storage-schemas. Currently, the storage-schemas parser in CRNG drops these fields before uploading to Grafana Cloud/GEM. This PR fixes this - if either of these two fields are supplied for a rule, they will be uploaded as part of the storage-schemas.conf.

No validation is done on the `intervals` and `relativeToQuery`; we just copy over the string values from the input schemas file. This is because CRNG and Grafana Cloud/GEM have different storage-schemas.conf parsers. I didn't want to copy over the Grafana Cloud/GEM validation logic as we'd have to maintain two versions of the validation, and I wanted to implement something simple first to fix not being able to submit these fields at all. If there is a problem with `intervals` and `relativeToQuery`, the server-side validation will detect this and return a 400 error.

Ideally we should unify the schemas parsers in the future. That might cause some breaking changes though, so we'd have to be careful with how we approach that.

# Testing
Tested this version of CRNG successfully uploads schemas with the `intervals` and `relativeToQuery` fields to Grafana Cloud
