### PR TITLE
Deploy new packages when tag is added

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,39 @@ workflows:
               ignore: /.*/
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
+      - build:
+          requires:
+            - test
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
+      - package:
+          requires:
+            - test
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
+      - deploy:
+          requires:
+            - test
+            - build
+            - package
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
       - github_binaries:
           requires:
             - test
+            - build
+            - package
+            - deploy
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,9 @@ jobs:
     steps:
       - checkout
       - run: go install github.com/go-bindata/go-bindata/...@latest
-      - run: make build-linux # note, this runs go-bindata again
+      - run: make LINUX_PACKAGE_GOARCH=amd64 build-linux
+      - run: make LINUX_PACKAGE_GOARCH=arm64 build-linux
+      # note, build-linux runs go-bindata again
       # ideally we'd make sure that if go-bindata generated new content, we fail.
       # because devs should have run go-bindata and checked in changes already.
       # but because git checkout will change the timestamps and mode, it'll generate slight differences, and it's hard to filter those out
@@ -94,7 +96,8 @@ jobs:
             - carbon-relay-ng
             - carbon-relay-ng.exe
             - carbon-relay-ng-darwin
-            - carbon-relay-ng-linux
+            - carbon-relay-ng-linux-amd64
+            - carbon-relay-ng-linux-arm64
             - carbon-relay-ng-bsd
 
   package:

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,6 @@ carbon-relay-ng-linux-%:
 	cd ui/web && go-bindata -pkg web admin_http_assets/...
 	find . -name '*.go' | grep -v '^\.\/vendor' | xargs gofmt -w -s
 	GOOS=linux GOARCH=$* CGO_ENABLED=0 go build -ldflags "-X main.Version=$(VERSION)" -o $@ ./cmd/carbon-relay-ng
-	cp $@ carbon-relay-ng-linux
 
 test:
 	go test -v -race ./...


### PR DESCRIPTION
If you merge a new release into master and then add a new tag, the publish_release workflow fails ([example](https://app.circleci.com/pipelines/github/grafana/carbon-relay-ng/300/workflows/97c46183-8ee6-42a8-bcdb-2fc0201dc304/jobs/2779)). This is because packages aren't being deployed when a new tag is added. This PR adds the build/package/deploy steps to the publish_release workflow so correct packages are being deployed before the publish step.

Also fixed an [issue](https://app.circleci.com/pipelines/github/grafana/carbon-relay-ng/310/workflows/4b743e84-ea34-424c-9583-effcff1aba5a/jobs/2835) with packaging - after https://github.com/grafana/carbon-relay-ng/pull/479 the package step started failing because it was trying to build a binary before packaging it. The fix here was to make sure both the arm64/amd64 binaries are being created in the build step so the package step doesn't try to build a new binary.