### PR TITLE
Add arm64 architecture to goreleaser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,4 +171,4 @@ jobs:
         - checkout
         # - run: curl -sfL https://goreleaser.com/static/run | bash
         # For dry runs use the following and comment the above
-        - run: curl -sfL https://goreleaser.com/static/run | bash -s -- --rm-dist --skip-publish --snapshot
+        - run: curl -sfL https://goreleaser.com/static/run | bash -s -- --clean --skip-publish --snapshot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
       - test:
           filters:
             branches:
-              ignore: /.*/
+              only: fl/goreleaser-arm
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
       - build:
@@ -29,7 +29,7 @@ workflows:
             - test
           filters:
             branches:
-              ignore: /.*/
+              only: fl/goreleaser-arm
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
       - package:
@@ -38,7 +38,7 @@ workflows:
             - build
           filters:
             branches:
-              ignore: /.*/
+              only: fl/goreleaser-arm
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
       - deploy:
@@ -48,7 +48,7 @@ workflows:
             - package
           filters:
             branches:
-              ignore: /.*/
+              only: fl/goreleaser-arm
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
       - github_binaries:
@@ -59,7 +59,7 @@ workflows:
             - deploy
           filters:
             branches:
-              ignore: /.*/
+              only: fl/goreleaser-arm
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
 
@@ -169,6 +169,6 @@ jobs:
         - image: cimg/go:1.18
       steps:
         - checkout
-        - run: curl -sfL https://goreleaser.com/static/run | bash
+        # - run: curl -sfL https://goreleaser.com/static/run | bash
         # For dry runs use the following and comment the above
-        # - run: curl -sfL https://goreleaser.com/static/run | bash -s -- --rm-dist --skip-publish --snapshot
+        - run: curl -sfL https://goreleaser.com/static/run | bash -s -- --rm-dist --skip-publish --snapshot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
       - test:
           filters:
             branches:
-              only: fl/goreleaser-arm
+              ignore: /.*/
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
       - build:
@@ -29,7 +29,7 @@ workflows:
             - test
           filters:
             branches:
-              only: fl/goreleaser-arm
+              ignore: /.*/
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
       - package:
@@ -38,7 +38,7 @@ workflows:
             - build
           filters:
             branches:
-              only: fl/goreleaser-arm
+              ignore: /.*/
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
       - deploy:
@@ -48,7 +48,7 @@ workflows:
             - package
           filters:
             branches:
-              only: fl/goreleaser-arm
+              ignore: /.*/
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
       - github_binaries:
@@ -59,7 +59,7 @@ workflows:
             - deploy
           filters:
             branches:
-              only: fl/goreleaser-arm
+              ignore: /.*/
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
 
@@ -169,6 +169,6 @@ jobs:
         - image: cimg/go:1.18
       steps:
         - checkout
-        # - run: curl -sfL https://goreleaser.com/static/run | bash
+        - run: curl -sfL https://goreleaser.com/static/run | bash
         # For dry runs use the following and comment the above
-        - run: curl -sfL https://goreleaser.com/static/run | bash -s -- --clean --skip-publish --snapshot
+        # - run: curl -sfL https://goreleaser.com/static/run | bash -s -- --clean --skip-publish --snapshot

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,12 +13,12 @@ builds:
       - amd64
       - arm64
 archives:
-  name_template: >-
-    {{ .ProjectName }}_
-    {{- title .Os }}_
-    {{- if eq .Arch "amd64" }}x86_64
-    {{- else if eq .Arch "386" }}i386
-    {{- else }}{{ .Arch }}{{ end }}
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,12 +13,12 @@ builds:
       - amd64
       - arm64
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  name_template: >-
+    {{ .ProjectName }}_
+    {{- title .Os }}_
+    {{- if eq .Arch "amd64" }}x86_64
+    {{- else if eq .Arch "386" }}i386
+    {{- else }}{{ .Arch }}{{ end }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,7 @@ builds:
 archives:
   - name_template: >-
       {{ .ProjectName }}_
+      {{- .Version }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@ builds:
       - freebsd
     goarch:
       - amd64
+      - arm64
 archives:
   - replacements:
       darwin: Darwin


### PR DESCRIPTION
As requested by https://github.com/grafana/carbon-relay-ng/pull/506#pullrequestreview-1307565407

Tested here: https://app.circleci.com/pipelines/github/grafana/carbon-relay-ng/314/workflows/c8068722-1e83-4cab-83d1-6e5aea53b09c/jobs/2863

Also updated a couple of goreleaser settings that were deprecated

