### PR TITLE
Update golang version to 1.20.5 to address CVE-2023-29403

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
   test:
     working_directory: /home/circleci/go/src/github.com/grafana/carbon-relay-ng
     docker:
-      - image: cimg/go:1.20.3
+      - image: cimg/go:1.20.5
     steps:
       - checkout
       - run: make test
@@ -75,7 +75,7 @@ jobs:
   build:
     working_directory: /home/circleci/go/src/github.com/grafana/carbon-relay-ng
     docker:
-      - image: cimg/go:1.20.4
+      - image: cimg/go:1.20.5
     steps:
       - checkout
       - run: go install github.com/go-bindata/go-bindata/...@latest
@@ -166,7 +166,7 @@ jobs:
 
   github_binaries:
       docker:
-        - image: cimg/go:1.20.4
+        - image: cimg/go:1.20.5
       steps:
         - checkout
         - run: curl -sfL https://goreleaser.com/static/run | bash


### PR DESCRIPTION
Address CVE-2023-29403 by bumping to golang 1.20.5