### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # unreleased
 
-# v1.4.5: March 13, 2023
+# v1.4.5: March 13, 2024
 * Update go version to build from 1.21.8 for carbon-relay-ng images #544
 
 # v1.4.4: July 27, 2023


### PR DESCRIPTION
Correct release date for v1.4.5 in CHANGELOG.md.