### PR TITLE
Remove toki

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/streadway/amqp v0.0.0-20170521212453-dfe15e360485
 	github.com/stretchr/testify v1.8.4
-	github.com/taylorchu/toki v0.0.0-20141019163204-20e86122596c
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c
 )
 

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,6 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/taylorchu/toki v0.0.0-20141019163204-20e86122596c h1:FPVNYOiTjaGNfDYevBEiLLu9iSkBdvnfMcnR6qKkwbg=
-github.com/taylorchu/toki v0.0.0-20141019163204-20e86122596c/go.mod h1:YYyjUTaSaC2W8KSnbqKGHDKPd/e/8c88su0LP0NkUfk=
 github.com/tinylib/msgp v1.1.0 h1:9fQd+ICuRIu/ue4vxJZu6/LzxN0HwMds2nq/0cFvxHU=
 github.com/tinylib/msgp v1.1.0/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV0YCnDjqSL7/q/JyPhhJSPk=

--- a/imperatives/imperatives_test.go
+++ b/imperatives/imperatives_test.go
@@ -10,53 +10,53 @@ import (
 	"github.com/grafana/carbon-relay-ng/pkg/test"
 	"github.com/grafana/carbon-relay-ng/route"
 	"github.com/grafana/carbon-relay-ng/table"
-	"github.com/taylorchu/toki"
+	"github.com/grafana/carbon-relay-ng/tokre"
 )
 
 func TestScanner(t *testing.T) {
 	cases := []struct {
 		cmd string
-		exp []toki.Token
+		exp []tokre.Token
 	}{
 		{
 			"addBlock prefix collectd.localhost",
-			[]toki.Token{addBlock, word, word},
+			[]tokre.Token{addBlock, word, word},
 		},
 		{
 			`addBlock regex ^foo\..*\.cpu+`,
-			[]toki.Token{addBlock, word, word},
+			[]tokre.Token{addBlock, word, word},
 		},
 		{
 			`addAgg sum ^stats\.timers\.(app|proxy|static)[0-9]+\.requests\.(.*) stats.timers._sum_$1.requests.$2 10 20`,
-			[]toki.Token{addAgg, sumFn, word, word, num, num},
+			[]tokre.Token{addAgg, sumFn, word, word, num, num},
 		},
 		{
 			`addAgg avg ^stats\.timers\.(app|proxy|static)[0-9]+\.requests\.(.*) stats.timers._avg_$1.requests.$2 5 10`,
-			[]toki.Token{addAgg, avgFn, word, word, num, num},
+			[]tokre.Token{addAgg, avgFn, word, word, num, num},
 		},
 		{
 			"addRoute sendAllMatch carbon-default  127.0.0.1:2005 spool=true pickle=false",
-			[]toki.Token{addRouteSendAllMatch, word, sep, word, optSpool, optTrue, optPickle, optFalse},
+			[]tokre.Token{addRouteSendAllMatch, word, sep, word, optSpool, optTrue, optPickle, optFalse},
 		},
 		{
 			"addRoute sendAllMatch carbon-tagger sub==  127.0.0.1:2006",
-			[]toki.Token{addRouteSendAllMatch, word, optSub, word, sep, word},
+			[]tokre.Token{addRouteSendAllMatch, word, optSub, word, sep, word},
 		},
 		{
 			"addRoute sendFirstMatch analytics regex=(Err/s|wait_time|logger)  graphite.prod:2003 prefix=prod. spool=true pickle=true  graphite.staging:2003 prefix=staging. spool=true pickle=true",
-			[]toki.Token{addRouteSendFirstMatch, word, optRegex, word, sep, word, optPrefix, word, optSpool, optTrue, optPickle, optTrue, sep, word, optPrefix, word, optSpool, optTrue, optPickle, optTrue},
+			[]tokre.Token{addRouteSendFirstMatch, word, optRegex, word, sep, word, optPrefix, word, optSpool, optTrue, optPickle, optTrue, sep, word, optPrefix, word, optSpool, optTrue, optPickle, optTrue},
 		},
 		{
 			"addRoute sendFirstMatch myRoute1  127.0.0.1:2003 notPrefix=aaa notSub=bbb notRegex=ccc",
-			[]toki.Token{addRouteSendFirstMatch, word, sep, word, optNotPrefix, word, optNotSub, word, optNotRegex, word},
+			[]tokre.Token{addRouteSendFirstMatch, word, sep, word, optNotPrefix, word, optNotSub, word, optNotRegex, word},
 		},
 		//{ disabled cause tries to read the schemas.conf file
 		//	"addRoute grafanaNet grafanaNet  http://localhost:8081/metrics your-grafana.net-api-key /path/to/storage-schemas.conf",
-		//	[]toki.Token{addRouteGrafanaNet, word, sep, word, word},
+		//	[]tokre.Token{addRouteGrafanaNet, word, sep, word, word},
 		//},
 	}
 	for i, c := range cases {
-		s := toki.NewScanner(tokens)
+		s := tokre.NewScanner(tokens)
 		s.SetInput(strings.Replace(c.cmd, "  ", " ## ", -1))
 		for j, e := range c.exp {
 			r := s.Next()

--- a/tokre/README.md
+++ b/tokre/README.md
@@ -1,0 +1,6 @@
+# Tokre
+
+Tokenizer based on regular expressions.
+Built to be super simple.
+Caller provides a list of possible
+tokens and the regex definitions.

--- a/tokre/tokre.go
+++ b/tokre/tokre.go
@@ -1,0 +1,121 @@
+// Package tokre tokenizes based on regular expressions.
+package tokre
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type (
+	// Classifies the type of token encountered.
+	Token int
+
+	// Defines a token type, with the Pattern being a regex.
+	Def struct {
+		Token   Token
+		Pattern string
+		regex   *regexp.Regexp
+	}
+
+	// The position within the input in characters.
+	// Starting at (1,1). Note that multi-byte sequences must first
+	// be converted to characters prior to use with this tokenizer.
+	Position struct {
+		Line   int
+		Column int
+	}
+
+	// Created by NewScanner, this is the central place doing the tokenization.
+	Scanner struct {
+		defs     []Def
+		input    string
+		pos      Position
+		space_re *regexp.Regexp
+	}
+
+	// The resulting tokens.
+	// Each is from scanner.Next, and includes both the position and text found.
+	Result struct {
+		Token Token
+		Pos   Position
+		Value string
+	}
+)
+
+// Represents the end of input.
+const EOF Token = -1
+
+// Represents some sort of error occurred, the input could not be matched to any token def.
+const Error Token = -2
+
+// Create a scanner tokenizer.
+func NewScanner(defs []Def) *Scanner {
+	for i := range defs {
+		defs[i].regex = regexp.MustCompile("^" + defs[i].Pattern)
+	}
+	return &Scanner{
+		defs:     defs,
+		space_re: regexp.MustCompile(`^\s+`),
+	}
+}
+
+// Start the tokenizer with an input string.
+func (s *Scanner) SetInput(input string) {
+	s.input = input
+	s.pos = Position{1, 1}
+}
+
+// Get the next token from the input.
+func (s *Scanner) Next() Result {
+	s.skip_space()
+	tok := s.match()
+	s.consume(tok.Value)
+	return tok
+}
+
+func (s *Scanner) Peek() Result {
+	s.skip_space()
+	return s.match()
+}
+
+// Pretty printable Result.
+func (r Result) String() string {
+	return fmt.Sprintf("(Ln %d, Col %d): %d \"%s\"", r.Pos.Line, r.Pos.Column, r.Token, r.Value)
+}
+
+// Consumes input, updating the state of the tokenizer.
+func (s *Scanner) consume(text string) {
+	s.pos.Line += strings.Count(text, "\n")
+	last := strings.LastIndex(text, "\n")
+	if last != -1 {
+		s.pos.Column = 1
+	}
+	s.pos.Column += len(text) - last - 1
+
+	s.input = strings.TrimPrefix(s.input, text)
+}
+
+// Skip spaces.
+func (s *Scanner) skip_space() {
+	result := s.space_re.FindString(s.input)
+	if result == "" {
+		return
+	}
+	s.consume(result)
+}
+
+// Match against the first Def that is at the head of the input.
+func (s *Scanner) match() Result {
+	if len(s.input) == 0 {
+		return Result{Token: EOF, Pos: s.pos}
+	}
+	for _, r := range s.defs {
+		result := r.regex.FindStringIndex(s.input)
+		if result == nil {
+			continue
+		}
+		return Result{Token: r.Token, Pos: s.pos, Value: s.input[result[0]:result[1]]}
+	}
+	return Result{Token: Error, Pos: s.pos}
+}

--- a/tokre/tokre_test.go
+++ b/tokre/tokre_test.go
@@ -1,0 +1,42 @@
+package tokre
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	NUMBER Token = iota + 1
+	DASH
+	STRING
+	EXCLAMATION
+)
+
+func TestToker(t *testing.T) {
+	input := "3 -  2-1 - blast off!!!"
+
+	scanner := NewScanner([]Def{
+		{Token: NUMBER, Pattern: "[0-9]+"},
+		{Token: DASH, Pattern: `-`},
+		{Token: STRING, Pattern: "[a-z]+"},
+		{Token: EXCLAMATION, Pattern: "!+"},
+	})
+
+	scanner.SetInput(input)
+
+	expected := []Result{
+		{NUMBER, Position{1, 1}, "3"}, {DASH, Position{1, 3}, "-"},
+		{NUMBER, Position{1, 6}, "2"}, {DASH, Position{1, 7}, "-"},
+		{NUMBER, Position{1, 8}, "1"}, {DASH, Position{1, 10}, "-"},
+		{STRING, Position{1, 12}, "blast"}, {STRING, Position{1, 18}, "off"},
+		{EXCLAMATION, Position{1, 21}, "!!!"}, {EOF, Position{1, 24}, ""},
+	}
+	for _, exp := range expected {
+		token := scanner.Next()
+		assert.Equal(t, token.Token, exp.Token)
+		assert.Equal(t, token.Pos, exp.Pos)
+		assert.Equal(t, token.Value, exp.Value)
+		//t.Logf("%s", token)
+	}
+}


### PR DESCRIPTION
Remove the toki module, replaced with a rewritten tokre. This is a tokenizer based on regular expressions.
The API is similar, but not the same.
The tokre module is pulled into the same repo, as there are not many users of the original code.
Fixes issue https://github.com/grafana/carbon-relay-ng/issues/551