### PR TITLE
chore: fix tag pattern in workflow trigger

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     tags:
-      - 'v[0-9]+(\.[0-9]+)*(-.*)*'
+      - v[0-9]+.[0-9]+.[0-9]+**
   pull_request:
 
 permissions:


### PR DESCRIPTION
These are not regexes apparently, see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet