### PR TITLE
docker: build using distroless image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
-FROM alpine
+FROM alpine as builder
 RUN apk --update add --no-cache ca-certificates
-ADD carbon-relay-ng-linux-amd64 /bin/carbon-relay-ng
+RUN mkdir /var/spool/carbon-relay-ng
+
+# But the final image is distroless
+FROM gcr.io/distroless/static-debian12
+COPY --from=builder /etc/ssl /etc/ssl
+COPY --from=builder /var/spool /var/spool
+
 VOLUME /conf
 ADD examples/carbon-relay-ng.ini /conf/carbon-relay-ng.ini
-RUN mkdir /var/spool/carbon-relay-ng
+ADD carbon-relay-ng-linux-amd64 /bin/carbon-relay-ng
+
 ENTRYPOINT ["/bin/carbon-relay-ng"]
 CMD ["/conf/carbon-relay-ng.ini"]


### PR DESCRIPTION
This PR updates the dockerfile to use alpine as the builder image but base the final carbon-relay-ng image on a distroless image