### PR TITLE
Make duration parsing more flexible in storage schema parsing.

### DIFF
--- a/go-whisper/whisper_test.go
+++ b/go-whisper/whisper_test.go
@@ -29,11 +29,12 @@ func testParseRetentionDef(t *testing.T, retentionDef string, expectedPrecision,
 }
 
 func TestParseRetentionDef(t *testing.T) {
-	testParseRetentionDef(t, "1s:5m", 1, 300, false)
+	testParseRetentionDef(t, "1s:5min", 1, 300, false)
+	testParseRetentionDef(t, "1s:5minaf", 1, 300, true)
 	testParseRetentionDef(t, "1m:30m", 60, 30, false)
 	testParseRetentionDef(t, "1m", 0, 0, true)
 	testParseRetentionDef(t, "1m:30m:20s", 0, 0, true)
-	testParseRetentionDef(t, "1f:30s", 0, 0, true)
+	testParseRetentionDef(t, "1f:30seconds", 0, 0, true)
 	testParseRetentionDef(t, "1m:30f", 0, 0, true)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/kisielk/og-rek v1.2.0
 	github.com/metrics20/go-metrics20 v0.0.0-20180821133656-717ed3a27bf9
 	github.com/prometheus/procfs v0.15.1
+	github.com/raintank/dur v0.0.0-20220106223125-d7c6a541ef3a
 	github.com/sirupsen/logrus v1.9.3
 	github.com/streadway/amqp v1.1.0
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
+github.com/raintank/dur v0.0.0-20220106223125-d7c6a541ef3a h1:ic0R3TWw1y25d48s4aS1cVNarVq58zkzVna+ezzaa9o=
+github.com/raintank/dur v0.0.0-20220106223125-d7c6a541ef3a/go.mod h1:7BB8LeqBvE3vEKv3ZbgA324vRXhUVO9pT9UrKnYDnx8=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a h1:9ZKAASQSHhDYGoxY8uLVpewe1GDZ2vu2Tr/vTdVAkFQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=

--- a/route/grafananet_test.go
+++ b/route/grafananet_test.go
@@ -12,7 +12,7 @@ func TestNewGrafanaNetConfig(t *testing.T) {
 	// note: the goal of this test is not to strictly test the correctness of the schemas reading
 	// we have separate tests for that
 
-	schemasFile := test.TempFdOrFatal("carbon-relay-ng-TestNewGrafanaNetConfig-schemasFile-valid", "[default]\npattern = .*\nretentions = 10s:1d", t)
+	schemasFile := test.TempFdOrFatal("carbon-relay-ng-TestNewGrafanaNetConfig-schemasFile-valid", "[default]\npattern = .*\nretentions = 10min:1m", t)
 	defer os.Remove(schemasFile.Name())
 
 	otherFile := test.TempFdOrFatal("carbon-relay-ng-TestNewGrafanaNetConfig-otherFile", "this is not a schemas or aggregation file", t)


### PR DESCRIPTION
Grafana's schema parsing uses this raintank duration parsing function so we should support this larger range of units here too.