### PR TITLE
ci: fix docker tagging with `latest`

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -5,7 +5,7 @@ version=$(git describe --tags --always | sed 's/^v//')
 # note: we may want to extend this to also not tag as latest if working tree is dirty.
 # but i think because of how go bindata works, it probably makes a change in the working tree.
 tag=main
-[[ "$GITHUB_EVENT_NAME" = "push" ]] && [[ "$GITHUB_REF_TYPE" = "tag" ]] && [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && tag=latest
+[[ "$GITHUB_EVENT_NAME" = "push" ]] && [[ "$GITHUB_REF_TYPE" = "tag" ]] && [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && tag=latest
 
 
 docker build --tag=grafana/carbon-relay-ng:$tag .


### PR DESCRIPTION
Same as https://github.com/grafana/carbon-relay-ng/pull/590, missed this one