### PR TITLE
chore(dependabot): use main and not a branch

### DIFF
--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -5,7 +5,7 @@ permissions:
   contents: write
 jobs:
   call-workflow-passing-data:
-    uses: grafana/security-github-actions/.github/workflows/dependabot-automerge.yaml@dependabot-automerge
+    uses: grafana/security-github-actions/.github/workflows/dependabot-automerge.yaml@main
     with:
       packages-minor-autoupdate: '["cloud.google.com/go","github.com/Dieterbe/artisanalhistogram","github.com/Dieterbe/go-metrics","github.com/Dieterbe/topic","github.com/Shopify/sarama","github.com/aws/aws-sdk-go","github.com/bmizerany/assert","github.com/dgryski/go-linlog","github.com/elazarl/go-bindata-assetfs","github.com/golang/snappy","github.com/google/go-cmp","github.com/gorilla/handlers","github.com/gorilla/mux","github.com/grafana/configparser","github.com/grafana/metrictank","github.com/jpillora/backoff","github.com/kisielk/og-rek","github.com/metrics20/go-metrics20","github.com/prometheus/procfs","github.com/sirupsen/logrus","github.com/streadway/amqp","github.com/stretchr/testify","github.com/taylorchu/toki","github.com/xdg/scram"]'
     secrets: inherit

--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -1,5 +1,5 @@
 name: Dependabot reviewer
-on: pull_request_target
+on: pull_request
 permissions:
   pull-requests: write
   contents: write


### PR DESCRIPTION
We were stuck on a branch for 2 years, probably outdated by now.
Sync with the doc in https://github.com/grafana/security-appsec/blob/f6e0281c64b6a895cec6830b6ac14b7d737d7691/docs/appsec-tools/how-to-configure-renovate.md#configure-renovate