### PR TITLE
fix(actions): do not pass secrets undefined on receiver side

### DIFF
--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -8,7 +8,3 @@ jobs:
     uses: grafana/security-github-actions/.github/workflows/dependabot-automerge.yaml@main
     with:
       packages-minor-autoupdate: '["cloud.google.com/go","github.com/Dieterbe/artisanalhistogram","github.com/Dieterbe/go-metrics","github.com/Dieterbe/topic","github.com/Shopify/sarama","github.com/aws/aws-sdk-go","github.com/bmizerany/assert","github.com/dgryski/go-linlog","github.com/elazarl/go-bindata-assetfs","github.com/golang/snappy","github.com/google/go-cmp","github.com/gorilla/handlers","github.com/gorilla/mux","github.com/grafana/configparser","github.com/grafana/metrictank","github.com/jpillora/backoff","github.com/kisielk/og-rek","github.com/metrics20/go-metrics20","github.com/prometheus/procfs","github.com/sirupsen/logrus","github.com/streadway/amqp","github.com/stretchr/testify","github.com/taylorchu/toki","github.com/xdg/scram"]'
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      DEPENDABOTREVIEWER_ID: ${{ secrets.DEPENDABOTREVIEWER_ID }}
-      DEPENDABOTREVIEWER_PEM: ${{ secrets.DEPENDABOTREVIEWER_PEM }}


### PR DESCRIPTION
Related to https://github.com/grafana/db-upstream-squad/issues/717

We got
```
Invalid workflow file: .github/workflows/dependabot-reviewer.yml#L12
The workflow is not valid. .github/workflows/dependabot-reviewer.yml (Line: 12, Col: 21): Invalid secret, GITHUB_TOKEN is not defined in the referenced workflow. .github/workflows/dependabot-reviewer.yml (Line: 13, Col: 30): Invalid secret, DEPENDABOTREVIEWER_ID is not defined in the referenced workflow.
```