### PR TITLE
Bump go toolchain to 1.24.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # unreleased
 
+# v1.5.6: July  21, 2025
+* Bump go toolchain to 1.24.4
+
 # v1.5.5: May 21, 2025
 * Migrate to `aws-sdk-go-v2`
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/grafana/carbon-relay-ng
 
 go 1.24
 
-toolchain go1.24.2
+toolchain go1.24.4
 
 require (
 	cloud.google.com/go/pubsub v1.49.0


### PR DESCRIPTION
Resolves CVE-2025-22874