### PR TITLE
chore(ci): fix CI error on success

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,7 +117,9 @@ jobs:
           docker push grafana/carbon-relay-ng:$tag
           # To preserve compatibility, also push the "master" tag we built in
           # build_docker.sh.
-          [[ "$tag" == "main" ]] && docker push grafana/carbon-relay-ng:master
+          if [[ "$tag" == "main" ]] ; then
+            docker push grafana/carbon-relay-ng:master
+          fi
 
   github_binaries:
     if: github.ref_type == 'tag'


### PR DESCRIPTION
When we check for tag == "main" and it's not true, the shell script doesn't fail, however the last error code is still 1 so github thinks it failed, see last runs, e.g.
https://github.com/grafana/carbon-relay-ng/actions/runs/16931017524/job/47976641141

Do a proper if statement to not return 1.