### PR TITLE
chore: bump Go version to 1.25.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639 # v4 # zizmor: ignore[cache-poisoning]
         with:
-          go-version: 1.25.8
+          go-version: 1.25.9
       - run: make test
 
   build:
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639 # v4 # zizmor: ignore[cache-poisoning]
         with:
-          go-version: 1.25.8
+          go-version: 1.25.9
       - uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.235.0
         with:
           ruby-version: 3.3
@@ -146,7 +146,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639 # v4 # zizmor: ignore[cache-poisoning]
         with:
-          go-version: 1.25.8
+          go-version: 1.25.9
       - name: Run goreleaser
         run: curl -sfL https://goreleaser.com/static/run | bash
         env:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/carbon-relay-ng
 
-go 1.25.8
+go 1.25.9
 
 require (
 	cloud.google.com/go/pubsub v1.50.2


### PR DESCRIPTION
## Summary
- Update Go version from 1.25.8 to 1.25.9 in `go.mod`
- Update `go-version` in all three `actions/setup-go` steps in `.github/workflows/ci.yaml`

## Test plan
- [ ] CI passes with Go 1.25.9

Signed-off-by: György Krajcsovits <gyorgy.krajcsovits@grafana.com>

Coded with Claude Sonnet 4.6.