### PR TITLE
chore(release): prepare 1.5.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # unreleased
 
+# v1.5.14: April 17, 2026
+* Bump Go version to 1.25.9
+* Various minor dependency updates
+
 # v1.5.13: March 30, 2026
 * Bump Go version to 1.25.8
 * Various minor dependency updates


### PR DESCRIPTION
## Summary
- Add CHANGELOG entry for v1.5.14

## Changes since 1.5.13
* Bump Go version to 1.25.9
* Various minor dependency updates

## Test plan
- [ ] CI passes
- [ ] After merge, tag `v1.5.14` to trigger release

Signed-off-by: György Krajcsovits <gyorgy.krajcsovits@grafana.com>

Coded with Claude Sonnet 4.6.