### PR TITLE
chore(ci): harden workflow permissions and update pinned actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,31 +9,32 @@ on:
   pull_request:
 
 permissions:
-  contents: write # zizmor: ignore[excessive-permissions]
-  id-token: write # zizmor: ignore[excessive-permissions]
+  contents: read
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4 # zizmor: ignore[cache-poisoning]
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.0.0
         with:
           go-version: 1.25.9
+          cache: false
       - run: make test
 
   build:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4 # zizmor: ignore[cache-poisoning]
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.0.0
         with:
           go-version: 1.25.9
+          cache: false
       - uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.235.0
         with:
           ruby-version: 3.3
@@ -70,8 +71,11 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Download package artifacts
@@ -85,7 +89,7 @@ jobs:
       - name: Install package_cloud
         run: gem install package_cloud
       - name: Set PACKAGECLOUD_TOKEN
-        uses: grafana/shared-workflows/actions/get-vault-secrets@2d5a0678eb32b0fd6655b4f7a3a7ec72eaf530ca
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
         with:
           repo_secrets: |
             PACKAGECLOUD_TOKEN=packagecloud:token
@@ -104,7 +108,7 @@ jobs:
       - name: Load Docker image
         run: docker load -i build/carbon-relay-ng.tar
       - name: Login to DockerHub
-        uses: grafana/shared-workflows/actions/dockerhub-login@2d5a0678eb32b0fd6655b4f7a3a7ec72eaf530ca
+        uses: grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7 # dockerhub-login/v1.0.4
       - name: Push Docker image
         run: |
           set -e
@@ -140,13 +144,16 @@ jobs:
     if: github.ref_type == 'tag'
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4 # zizmor: ignore[cache-poisoning]
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.0.0
         with:
           go-version: 1.25.9
+          cache: false
       - name: Run goreleaser
         run: curl -sfL https://goreleaser.com/static/run | bash
         env:


### PR DESCRIPTION
## Summary
- Apply least-privilege `permissions:` per job — workflow defaults to `contents: read`; `deploy` adds `id-token: write` (Vault OIDC); `github_binaries` adds `contents: write` (goreleaser). Removes the two `zizmor: ignore[excessive-permissions]` suppressions.
- Bump `actions/checkout` v3 → v6.0.2 and `actions/setup-go` v4 → v6.0.0; keep `cache: false` so the cache-poisoning lint is addressed at the source rather than ignored.
- Repin `grafana/shared-workflows` actions to tagged releases (`get-vault-secrets/v1.3.2`, `dockerhub-login/v1.0.4`) instead of an arbitrary untagged monorepo commit.

## Test plan
- [ ] PR CI (`test`, `build` jobs) passes with the reduced permissions.
- [ ] On a tag push, `deploy` job successfully fetches Vault secrets via OIDC and pushes images.
- [ ] On a tag push, `github_binaries` job successfully creates GitHub release artifacts via goreleaser.
- [ ] `zizmor` reports no remaining findings on the workflow.

Coded with Claude Opus 4.7.