### PR TITLE
ci: publish images via GAR mirror; drop direct DockerHub push

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,10 +118,9 @@ jobs:
             version=$(cat build/version.txt)
             tags="${version}"
           else
-            # Main branch: push to dev GAR with immutable <branch>-<sha> tags.
-            # Both main- and master- are pushed for downstream compat.
+            # Main branch: push to dev GAR with immutable main-<sha> tag.
             internal_env=dev
-            tags="main-${short_sha}"$'\n'"master-${short_sha}"
+            tags="main-${short_sha}"
           fi
           {
             echo "internal_env=${internal_env}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,10 +107,12 @@ jobs:
         run: cp build/bin/* .
       - name: Compute image tags and target environment
         id: image
+        env:
+          REF_TYPE: ${{ github.ref_type }}
         run: |
           set -e
           short_sha="${GITHUB_SHA::7}"
-          if [ "${{ github.ref_type }}" = "tag" ]; then
+          if [ "$REF_TYPE" = "tag" ]; then
             # Release: push to prod GAR with a single <version> tag.
             internal_env=prod
             version=$(cat build/version.txt)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,9 +53,7 @@ jobs:
       - name: Make packages
         run: make packages
       - name: Build Docker image
-        run: |
-          make docker
-          docker save -o build/carbon-relay-ng.tar grafana/carbon-relay-ng
+        run: make docker
       - name: Store version
         run: git describe --tags --always | sed 's/^v//' > build/version.txt
       - name: Upload package artifacts
@@ -105,38 +103,47 @@ jobs:
           package_cloud push $repo/debian/buster build/deb-systemd/carbon-relay-ng-*.deb
           package_cloud push $repo/el/6 build/centos-6/carbon-relay-ng-*.el6.*.rpm
           package_cloud push $repo/el/7 build/centos-7/carbon-relay-ng-*.el7.*.rpm
-      - name: Load Docker image
-        run: docker load -i build/carbon-relay-ng.tar
-      - name: Login to DockerHub
-        uses: grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7 # dockerhub-login/v1.0.4
-      - name: Push Docker image
+      - name: Position binary for image build context
+        run: cp build/bin/* .
+      - name: Compute image tags and target environment
+        id: image
         run: |
           set -e
-          version=$(cat build/version.txt)
-          docker push grafana/carbon-relay-ng:$version
-          # only versions without a hyphen - e.g. actual releases - are tagged as latest.
-          # in-between-release versions are tagged as main.
-          tag=latest
-          [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && tag=main
-          docker push grafana/carbon-relay-ng:$tag
-          # To preserve compatibility, also push the "master" tag we built in
-          # build_docker.sh.
-          if [[ "$tag" == "main" ]] ; then
-            docker push grafana/carbon-relay-ng:master
+          short_sha="${GITHUB_SHA::7}"
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            # Release: push to prod GAR with a single <version> tag.
+            internal_env=prod
+            version=$(cat build/version.txt)
+            tags="${version}"
+          else
+            # Main branch: push to dev GAR with immutable <branch>-<sha> tags.
+            # Both main- and master- are pushed for downstream compat.
+            internal_env=dev
+            tags="main-${short_sha}"$'\n'"master-${short_sha}"
           fi
-      - name: Read version
-        id: version
-        run: echo "tag=$(cat build/version.txt)" >> $GITHUB_OUTPUT
-      - run: cp build/bin/* .
-      - name: Push image to GAR
-        uses: grafana/shared-workflows/actions/docker-build-push-image@ef27c620a88acc9f3007f30be5e9407324e8975b # v0.3.0
+          {
+            echo "internal_env=${internal_env}"
+            echo "tags<<EOF"
+            echo "${tags}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Push image to internal GAR
+        uses: grafana/shared-workflows/actions/docker-build-push-image@34f27887c37cafe70d34af57dfc86b468a31b8c4 # docker-build-push-image/v0.3.3
         with:
-          tags: |-
-            "${{ steps.version.outputs.tag }}"
-            ${{ github.ref_type == 'tag' && 'latest' || 'main' }}
+          tags: ${{ steps.image.outputs.tags }}
+          context: .
+          gar-environment: ${{ steps.image.outputs.internal_env }}
+          gar-image: carbon-relay-ng
+          push: true
+          registries: gar
+      - name: Push image to Docker Hub mirror staging
+        uses: grafana/shared-workflows/actions/docker-build-push-image@34f27887c37cafe70d34af57dfc86b468a31b8c4 # docker-build-push-image/v0.3.3
+        with:
+          tags: ${{ steps.image.outputs.tags }}
           context: .
           gar-environment: prod
           gar-image: carbon-relay-ng
+          gar-repository: dockerhub-carbon-relay-ng-prod-mirror
           push: true
           registries: gar
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,6 +109,7 @@ jobs:
         id: image
         env:
           REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           set -e
           short_sha="${GITHUB_SHA::7}"
@@ -117,10 +118,13 @@ jobs:
             internal_env=prod
             version=$(cat build/version.txt)
             tags="${version}"
-          else
+          elif [ "$REF_TYPE" = "branch" ] && [ "$REF_NAME" = "main" ]; then
             # Main branch: push to dev GAR with immutable main-<sha> tag.
             internal_env=dev
             tags="main-${short_sha}"
+          else
+            echo "Refusing to publish image for unexpected ref: type=$REF_TYPE name=$REF_NAME" >&2
+            exit 1
           fi
           {
             echo "internal_env=${internal_env}"


### PR DESCRIPTION
## Summary

The shared DockerHub write token previously used by CI has been disabled. This PR migrates the image publish flow to push to GAR; a mirror service handles the copy to `docker.io/grafana/carbon-relay-ng`.

## Changes

- **`build` job**: drop the docker save tarball. `make docker` still runs on every PR to validate the Dockerfile builds.
- **`deploy` job**:
  - Drop the `dockerhub-login` step and the raw `docker push grafana/carbon-relay-ng:...` block.
  - Drop the redundant single `docker-build-push-image` step that rebuilt the image with mixed `:latest` / `:main` tags.
  - Two `docker-build-push-image` invocations (sharing gha cache so the second pass is layer-reuse):
    - **Internal GAR** — `docker-carbon-relay-ng-dev` on main pushes; `docker-carbon-relay-ng-prod` on tag pushes.
    - **Mirror staging** — `dockerhub-carbon-relay-ng-prod-mirror` on every push (this is what the mirror service watches).
- **Tag scheme**:
  - Release tags (`vX.Y.Z`): `<version>` only. No `:latest`.
  - Main branch pushes: `main-<short-sha>` (immutable, replacing the prior mutable `:main` / `:master` tags).
- **Backward-compat caveat**: the existing mutable `:master` and `:main` tags on Docker Hub will freeze at their last values. Anything pulling `grafana/carbon-relay-ng:master` (or `:main`) should migrate to a `:main-<sha>` or `:<version>` pin.
- **zizmor**: `github.ref_type` is threaded through an `env:` block instead of inline `${{ ... }}` template expansion inside `run:`, to satisfy the template-injection lint.
- Bump `docker-build-push-image` v0.3.0 → v0.3.3.

## Test plan

- [x] PR CI passes (test + build, with `make docker` still validating the Dockerfile).
- [x] zizmor / GitHub Advanced Security scan passes.
- [ ] On merge to main: GAR receives `docker-carbon-relay-ng-dev/carbon-relay-ng:main-<sha>`; the same tag appears on `dockerhub-carbon-relay-ng-prod-mirror`; the mirror service copies it to `docker.io/grafana/carbon-relay-ng:main-<sha>`.
- [ ] On the next release tag push: `docker-carbon-relay-ng-prod/carbon-relay-ng:<version>` + same tag on the mirror staging repo + `docker.io/grafana/carbon-relay-ng:<version>`.
- [ ] No `:latest`, `:main`, or `:master` tag is published anywhere by this workflow.

Coded with Claude Opus 4.7.