### PR TITLE
docs: update for frozen Docker image tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # unreleased
+* The mutable `latest`, `main` and `master` tags are now frozen at their last value and will no longer update. Pin to release versions or  `main-<short-sha>` tags (build from `main`). See [installation docs](https://github.com/grafana/carbon-relay-ng/blob/main/docs/installation-building.md#docker-images).
 
 # v1.5.14: April 17, 2026
 * Bump Go version to 1.25.9

--- a/docs/installation-building.md
+++ b/docs/installation-building.md
@@ -27,8 +27,10 @@ See [dockerhub](https://hub.docker.com/r/grafana/carbon-relay-ng/).
 
 You can use these tags:
 
-* `latest`: the latest official stable release
-* `main`: latest build from main. these versions typically bring improvements but possibly also new bugs
+* `<version>` (e.g. `1.5.14`): an official stable release. Pin to one of these for reproducible deployments.
+* `main-<short-sha>`: an immutable build from the corresponding commit on the `main` branch. These typically bring improvements but possibly also new bugs.
+
+> **Note:** the mutable `latest`, `main` and `master` tags are no longer updated and are frozen at their last published value. Use an immutable `main-<short-sha>` tag or pin to a release version instead.
 
 
 # Building from source

--- a/examples/k8s/deployment.yaml
+++ b/examples/k8s/deployment.yaml
@@ -36,7 +36,7 @@ spec:
                 secretKeyRef:
                   key: api_key
                   name: crng-metrics-key
-          image: grafana/carbon-relay-ng:main
+          image: grafana/carbon-relay-ng:1.5.14
           imagePullPolicy: Always
           name: carbon-relay-ng
           ports:

--- a/jsonnet/lib/carbon-relay-ng/crng.libsonnet
+++ b/jsonnet/lib/carbon-relay-ng/crng.libsonnet
@@ -1,7 +1,7 @@
 local k = import 'ksonnet-util/kausal.libsonnet';
 {
   _images+:: {
-    carbon_relay_ng: 'grafana/carbon-relay-ng:main',
+    carbon_relay_ng: 'grafana/carbon-relay-ng:1.5.14',
   },
 
   _config+:: {


### PR DESCRIPTION
Updates docs and examples to reflect the Docker image publishing changes from PRs #742-746. The mutable `latest`, `main`, and `master` tags are now frozen. Users should pin to release versions or use immutable `main-<short-sha>` tags instead.
