### PR TITLE
ci(renovate): hold PRs until stability checks pass

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,7 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: ['github>grafana/grafana-renovate-config//presets/base'],
+  // Hold PRs until internal checks (e.g. minimumReleaseAge) pass, instead of
+  // opening them immediately with a pending renovate/stability-days check.
+  prCreation: 'not-pending',
+}


### PR DESCRIPTION
Adds a minimal Renovate config so dependency PRs are withheld until their stability window passes, instead of opening immediately with a pending `renovate/stability-days` check.
