### PR TITLE
build: update Go to 1.25.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.0.0
         with:
-          go-version: 1.25.9
+          go-version: 1.25.11
           cache: false
       - run: make test
 
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.0.0
         with:
-          go-version: 1.25.9
+          go-version: 1.25.11
           cache: false
       - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
@@ -182,7 +182,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.0.0
         with:
-          go-version: 1.25.9
+          go-version: 1.25.11
           cache: false
       - name: Run goreleaser
         run: curl -sfL https://goreleaser.com/static/run | bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # unreleased
+
+# v1.5.16: June 8, 2026
 * Bump Go version to 1.25.11
-* Produce DEB/RPM packages with goreleaser nfpm #770
-* Various minor dependency updates, including security fixes for `golang.org/x/net` and `golang.org/x/crypto`
+* Various minor dependency updates
+* Produce DEB/RPM packages with goreleaser nfpm
 
 # v1.5.15: June 1, 2026
 * The mutable `latest`, `main` and `master` tags are now frozen at their last value and will no longer update. Pin to release versions or  `main-<short-sha>` tags (build from `main`). See [installation docs](https://github.com/grafana/carbon-relay-ng/blob/main/docs/installation-building.md#docker-images).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # unreleased
+* Bump Go version to 1.25.11
+* Produce DEB/RPM packages with goreleaser nfpm #770
+* Various minor dependency updates, including security fixes for `golang.org/x/net` and `golang.org/x/crypto`
 
 # v1.5.15: June 1, 2026
 * The mutable `latest`, `main` and `master` tags are now frozen at their last value and will no longer update. Pin to release versions or  `main-<short-sha>` tags (build from `main`). See [installation docs](https://github.com/grafana/carbon-relay-ng/blob/main/docs/installation-building.md#docker-images).

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/carbon-relay-ng
 
-go 1.25.9
+go 1.25.11
 
 require (
 	cloud.google.com/go/pubsub v1.50.2


### PR DESCRIPTION
Updates Go from 1.25.9 to the latest 1.25.x patch release (1.25.11) in `go.mod` and the CI workflow.


Also prepare changelog for a release.