### PR TITLE
chore: bump Go version to 1.26.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: 1.25.12
+          go-version: 1.26.8
           cache: false
       - run: make test
 
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: 1.25.12
+          go-version: 1.26.8
           cache: false
       - name: Install go-bindata
         run: go install github.com/go-bindata/go-bindata/...@latest
@@ -150,7 +150,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: 1.25.12
+          go-version: 1.26.8
           cache: false
       - name: Run goreleaser
         run: curl -sfL https://goreleaser.com/static/run | bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # unreleased
+* Bump Go version to 1.26.8
 
 # v1.5.18: August 10, 2026
 * Bump Go version to 1.25.12

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/carbon-relay-ng
 
-go 1.25.12
+go 1.26.8
 
 require (
 	cloud.google.com/go/pubsub v1.51.0


### PR DESCRIPTION
## Summary
- Bumps `go.mod`'s `go` directive and the CI `actions/setup-go` pin (all three jobs: `test`, `build`, `github_binaries`) from `1.25.12` to `1.26.8` (latest stable 1.26.x patch), matching the pattern of prior Go bump PRs (e.g. #707, #699) that keep both files in lockstep.
- Needed because #840 (`golang.org/x/crypto` → v0.56.0) requires `go 1.26.0`, and CI currently fails there with `go.mod requires go >= 1.26.0 (running go 1.25.12)`.
- Adds a changelog entry under `# unreleased`.

## Test plan
- [x] `go build ./...` succeeds locally
- [ ] CI passes on this PR
- [ ] Rebase/re-run CI on #840 to confirm its `test` job now passes

Signed-off-by: György Krajcsovits <gyorgy.krajcsovits@grafana.com>